### PR TITLE
feat: M2 로그 파일 탐색 및 JSONL 파싱

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,10 +150,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -111,10 +230,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "proc-macro2"
@@ -135,11 +318,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rwd"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
+ "dirs",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"
@@ -159,6 +412,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,10 +444,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -184,3 +561,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+dirs = "6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // mod 키워드로 모듈을 선언합니다.
 // Rust는 파일 하나가 모듈 하나에 대응됩니다 — cli.rs 파일이 cli 모듈이 됩니다 (Rust Book Ch.7 참조).
 mod cli;
+mod parser;
 
 // use 키워드로 다른 모듈의 항목을 현재 스코프로 가져옵니다.
 use clap::Parser;
@@ -15,7 +16,61 @@ fn main() {
     // Rust 컴파일러는 모든 변형(variant)을 처리했는지 검사합니다 — 빠뜨리면 컴파일 에러가 납니다.
     match args.command {
         Commands::Today => {
-            println!("rwd today — 오늘의 개발 인사이트를 분석합니다. (M2에서 구현 예정)");
+            // run_today()가 Err를 반환하면 에러 메시지를 출력하고 종료합니다.
+            // if let은 Result가 특정 variant인 경우만 처리합니다 (Rust Book Ch.6.3 참조).
+            if let Err(e) = run_today() {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
         }
     }
+}
+
+/// 오늘의 세션 로그를 파싱하고 요약 정보를 출력합니다.
+/// 별도 함수로 분리하여 Result를 반환하면, ?로 에러를 깔끔하게 전파할 수 있습니다 (Rust Book Ch.9 참조).
+fn run_today() -> Result<(), parser::ParseError> {
+    let today = chrono::Utc::now().date_naive();
+    let base_dir = parser::discover_log_dir()?;
+
+    println!("Scanning: {}", base_dir.display());
+
+    let mut all_entries = Vec::new();
+
+    // 모든 프로젝트 디렉토리를 순회하며 오늘의 로그를 수집합니다.
+    for project_dir in parser::list_project_dirs()? {
+        for session_file in parser::list_session_files(&project_dir)? {
+            let entries = parser::parse_jsonl_file(&session_file)?;
+            // filter_entries_by_date는 Vec의 소유권을 가져가고 필터된 Vec을 반환합니다.
+            let today_entries = parser::filter_entries_by_date(entries, today);
+            // .extend()는 다른 Vec의 모든 요소를 현재 Vec에 추가합니다 (Rust Book Ch.8.1 참조).
+            all_entries.extend(today_entries);
+        }
+    }
+
+    if all_entries.is_empty() {
+        println!("No log entries found for today ({today}).");
+        return Ok(());
+    }
+
+    let summaries = parser::summarize_entries(&all_entries);
+
+    println!("\n=== rwd today ({today}) ===");
+    println!("Sessions: {}", summaries.len());
+
+    for s in &summaries {
+        // &s.session_id[..8]은 문자열의 처음 8글자만 슬라이스합니다 (Rust Book Ch.4.3 참조).
+        let total_in = s.total_input_tokens
+            + s.total_cache_creation_tokens
+            + s.total_cache_read_tokens;
+        println!("\nSession: {}...", &s.session_id[..8]);
+        println!("  User messages:      {}", s.user_count);
+        println!("  Assistant messages:  {}", s.assistant_count);
+        println!("  Tool uses:          {}", s.tool_use_count);
+        println!(
+            "  Tokens (in/out):    {}/{}",
+            total_in, s.total_output_tokens
+        );
+    }
+
+    Ok(())
 }

--- a/src/parser/claude.rs
+++ b/src/parser/claude.rs
@@ -1,0 +1,475 @@
+// Claude Code 세션 로그(.jsonl) 파서
+//
+// JSONL 파일의 각 줄은 독립된 JSON 객체이며, "type" 필드로 종류가 구분됩니다.
+// serde 크레이트를 사용하여 JSON을 Rust 구조체로 자동 변환(역직렬화)합니다.
+
+// serde 역직렬화를 위해 필드를 선언하지만, M2에서는 일부 필드를 아직 읽지 않습니다.
+// M3(LLM 분석)에서 활용할 예정이므로 dead_code 경고를 허용합니다.
+// #![...]은 "이 모듈 전체에 속성을 적용"하는 내부 속성입니다 (#[...]은 다음 항목에만 적용).
+#![allow(dead_code)]
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+// === 데이터 타입 정의 ===
+
+/// JSONL 파일의 각 줄을 나타내는 열거형(enum).
+/// enum은 "여러 가능한 형태 중 하나"를 표현합니다 (Rust Book Ch.6 참조).
+///
+/// #[serde(tag = "type")]은 JSON의 "type" 필드 값으로 variant를 결정합니다.
+/// 예: {"type": "user", ...} → LogEntry::User(UserEntry { ... })
+///
+/// rename_all = "kebab-case"는 PascalCase variant 이름을 kebab-case로 변환합니다.
+/// 예: FileHistorySnapshot → "file-history-snapshot"
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum LogEntry {
+    User(UserEntry),
+    Assistant(AssistantEntry),
+    Progress(ProgressEntry),
+    System(SystemEntry),
+    #[serde(rename = "file-history-snapshot")]
+    FileHistorySnapshot(FileHistorySnapshotEntry),
+    // 새로운 로그 타입이 추가되어도 파싱이 실패하지 않도록 catch-all variant를 둡니다.
+    // ContentBlock의 #[serde(other)]와 같은 역할입니다.
+    #[serde(untagged)]
+    Other(serde_json::Value),
+}
+
+/// 사용자 메시지 엔트리
+/// #[serde(rename_all = "camelCase")]는 Rust의 snake_case 필드를 JSON의 camelCase에 매핑합니다.
+/// 예: session_id ↔ "sessionId"
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserEntry {
+    pub timestamp: DateTime<Utc>,
+    pub session_id: String,
+    pub uuid: String,
+    // Option<T>는 "값이 있거나 없거나"를 표현합니다 (Rust Book Ch.6.1 참조).
+    // JSON에서 해당 필드가 없으면 None이 됩니다 (#[serde(default)] 덕분).
+    #[serde(default)]
+    pub message: Option<serde_json::Value>,
+}
+
+/// 어시스턴트(AI) 응답 엔트리
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssistantEntry {
+    pub timestamp: DateTime<Utc>,
+    pub session_id: String,
+    pub uuid: String,
+    #[serde(default)]
+    pub message: Option<AssistantMessage>,
+}
+
+/// 어시스턴트 메시지의 상세 구조
+#[derive(Debug, Deserialize)]
+pub struct AssistantMessage {
+    #[serde(default)]
+    pub model: Option<String>,
+    // Vec<T>는 가변 길이 배열입니다 (Rust Book Ch.8.1 참조).
+    #[serde(default)]
+    pub content: Vec<ContentBlock>,
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+/// 어시스턴트 메시지의 content 배열 안에 올 수 있는 블록 타입들.
+/// #[serde(tag = "type")]으로 "type" 필드 값에 따라 variant가 결정됩니다.
+/// rename_all = "snake_case"는 PascalCase를 snake_case로 변환합니다.
+/// 예: ToolUse → "tool_use"
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Thinking {
+        #[serde(default)]
+        thinking: Option<String>,
+    },
+    Text {
+        #[serde(default)]
+        text: Option<String>,
+    },
+    ToolUse {
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        id: Option<String>,
+    },
+    ToolResult {
+        #[serde(default)]
+        content: Option<serde_json::Value>,
+    },
+    // #[serde(other)]는 알 수 없는 타입을 이 variant로 매핑합니다.
+    // 새로운 블록 타입이 추가되어도 파싱이 실패하지 않습니다.
+    #[serde(other)]
+    Unknown,
+}
+
+/// API 토큰 사용량
+/// Claude API는 캐시 히트/생성 토큰을 별도 필드로 분리합니다.
+/// 총 입력 토큰 = input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+#[derive(Debug, Deserialize)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    // 캐시에 새로 저장된 입력 토큰 수
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    // 캐시에서 읽어온 입력 토큰 수
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+}
+
+/// 진행 상황 엔트리 (에이전트 작업 진행 등)
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressEntry {
+    pub timestamp: DateTime<Utc>,
+    pub session_id: String,
+}
+
+/// 시스템 엔트리
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemEntry {
+    pub timestamp: DateTime<Utc>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+/// 파일 히스토리 스냅샷 엔트리 (M2에서는 상세 분석 불필요)
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileHistorySnapshotEntry {
+    #[serde(default)]
+    pub message_id: Option<String>,
+}
+
+/// 세션 로그의 요약 정보를 담는 구조체
+#[derive(Debug)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub user_count: usize,
+    pub assistant_count: usize,
+    pub tool_use_count: usize,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_cache_creation_tokens: u64,
+    pub total_cache_read_tokens: u64,
+}
+
+// === 파일 탐색 함수 ===
+
+/// ~/.claude/projects/ 디렉토리의 경로를 반환합니다.
+/// dirs 크레이트는 OS별 홈 디렉토리를 크로스플랫폼으로 찾아줍니다.
+///
+/// .ok_or()는 Option을 Result로 변환합니다 (Rust Book Ch.9 참조).
+/// Some(value) → Ok(value), None → Err(에러메시지)
+///
+/// .into()는 String을 Box<dyn Error>로 변환합니다.
+/// Rust의 From 트레이트 덕분에 가능합니다 (Rust Book Ch.10 참조).
+pub fn discover_log_dir() -> Result<PathBuf, super::ParseError> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+
+    let claude_projects = home.join(".claude").join("projects");
+
+    if !claude_projects.exists() {
+        return Err(format!(
+            "Claude projects directory not found: {}",
+            claude_projects.display()
+        )
+        .into());
+    }
+
+    Ok(claude_projects)
+}
+
+/// ~/.claude/projects/ 아래의 모든 프로젝트 디렉토리를 반환합니다.
+/// std::fs::read_dir()은 디렉토리의 엔트리를 순회하는 이터레이터를 반환합니다 (Rust Book Ch.12 참조).
+/// 각 엔트리는 Result<DirEntry>이므로 ?로 에러를 전파합니다.
+pub fn list_project_dirs() -> Result<Vec<PathBuf>, super::ParseError> {
+    let base = discover_log_dir()?;
+    let mut dirs = Vec::new();
+
+    for entry in std::fs::read_dir(&base)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            dirs.push(path);
+        }
+    }
+
+    Ok(dirs)
+}
+
+/// 특정 프로젝트 디렉토리 안의 모든 .jsonl 파일을 반환합니다.
+/// &Path는 경로의 빌림(borrow)입니다 — 소유권을 가져가지 않습니다 (Rust Book Ch.4 참조).
+/// PathBuf : String = Path : &str 관계입니다 (소유 vs 빌림).
+pub fn list_session_files(project_dir: &Path) -> Result<Vec<PathBuf>, super::ParseError> {
+    let mut files = Vec::new();
+
+    for entry in std::fs::read_dir(project_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        // .jsonl 확장자를 가진 파일만 선택합니다.
+        // if let과 &&를 결합하면 여러 조건을 한 줄에 표현할 수 있습니다 (Rust 2024 Edition).
+        // let chains: if 조건 안에서 패턴 매칭과 불리언 조건을 연결합니다.
+        if path.is_file()
+            && let Some(ext) = path.extension()
+            && ext == "jsonl"
+        {
+            files.push(path);
+        }
+    }
+
+    Ok(files)
+}
+
+// === JSONL 파싱 함수 ===
+
+/// 하나의 JSONL 파일을 읽어서 LogEntry 벡터로 변환합니다.
+/// 파싱에 실패한 줄은 건너뛰고 eprintln으로 경고합니다.
+///
+/// BufReader는 파일을 한 줄씩 효율적으로 읽습니다 (Rust Book Ch.12 참조).
+/// .lines()는 각 줄을 Result<String>으로 반환하는 이터레이터입니다.
+/// .enumerate()는 (인덱스, 값) 쌍을 반환합니다 (Rust Book Ch.13 참조).
+pub fn parse_jsonl_file(path: &Path) -> Result<Vec<LogEntry>, super::ParseError> {
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    let mut entries = Vec::new();
+
+    for (line_num, line_result) in reader.lines().enumerate() {
+        let line = line_result?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // match로 파싱 결과를 명시적으로 처리합니다 (Rust Book Ch.6.2 참조).
+        // Ok이면 entries에 추가, Err이면 경고 출력 후 다음 줄로 진행합니다.
+        match serde_json::from_str::<LogEntry>(&line) {
+            Ok(entry) => entries.push(entry),
+            Err(err) => {
+                eprintln!(
+                    "Warning: Failed to parse line {} in {}: {}",
+                    line_num + 1,
+                    path.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
+// === 필터링 및 요약 함수 ===
+
+/// LogEntry에서 timestamp를 추출하는 헬퍼 함수.
+/// 모든 variant가 timestamp를 가지지는 않으므로 Option을 반환합니다.
+/// match로 enum의 모든 variant를 처리합니다 — 빠뜨리면 컴파일 에러가 납니다 (Rust Book Ch.6.2 참조).
+pub fn entry_timestamp(entry: &LogEntry) -> Option<DateTime<Utc>> {
+    match entry {
+        LogEntry::User(e) => Some(e.timestamp),
+        LogEntry::Assistant(e) => Some(e.timestamp),
+        LogEntry::Progress(e) => Some(e.timestamp),
+        LogEntry::System(e) => Some(e.timestamp),
+        LogEntry::FileHistorySnapshot(_) | LogEntry::Other(_) => None,
+    }
+}
+
+/// 주어진 날짜에 해당하는 엔트리만 필터링합니다.
+///
+/// .into_iter()는 Vec의 소유권을 가져가는 이터레이터입니다 (Rust Book Ch.13.2 참조).
+/// .filter()는 클로저(익명 함수)를 받아 조건에 맞는 요소만 남깁니다.
+/// 클로저는 |파라미터| { 본문 } 형태로 작성합니다 (Rust Book Ch.13.1 참조).
+/// .collect()는 이터레이터를 다시 Vec로 변환합니다.
+pub fn filter_entries_by_date(entries: Vec<LogEntry>, date: NaiveDate) -> Vec<LogEntry> {
+    entries
+        .into_iter()
+        .filter(|entry| {
+            // .date_naive()는 DateTime<Utc>에서 날짜 부분만 추출합니다.
+            match entry_timestamp(entry) {
+                Some(ts) => ts.date_naive() == date,
+                None => false,
+            }
+        })
+        .collect()
+}
+
+/// 파싱된 엔트리들을 세션별로 그룹화하고 요약합니다.
+///
+/// HashMap은 키-값 쌍을 저장하는 자료구조입니다 (Rust Book Ch.8.3 참조).
+/// .entry().or_insert_with()는 키가 없으면 새 값을 삽입하고,
+/// 있으면 기존 값의 가변 참조를 반환합니다 — 효율적인 "있으면 업데이트, 없으면 삽입" 패턴입니다.
+pub fn summarize_entries(entries: &[LogEntry]) -> Vec<SessionSummary> {
+    let mut sessions: HashMap<String, SessionSummary> = HashMap::new();
+
+    for entry in entries {
+        // 세션 ID가 있는 엔트리만 처리합니다.
+        let session_id = match entry {
+            LogEntry::User(e) => &e.session_id,
+            LogEntry::Assistant(e) => &e.session_id,
+            LogEntry::Progress(e) => &e.session_id,
+            // continue는 현재 반복을 건너뛰고 다음 반복으로 넘어갑니다.
+            LogEntry::System(_) | LogEntry::FileHistorySnapshot(_) | LogEntry::Other(_) => continue,
+        };
+
+        // .clone()은 값의 복사본을 만듭니다 (Rust Book Ch.4 참조).
+        // HashMap의 키로 사용하려면 소유된(owned) String이 필요합니다.
+        let summary = sessions
+            .entry(session_id.clone())
+            .or_insert_with(|| SessionSummary {
+                session_id: session_id.clone(),
+                user_count: 0,
+                assistant_count: 0,
+                tool_use_count: 0,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                total_cache_creation_tokens: 0,
+                total_cache_read_tokens: 0,
+            });
+
+        match entry {
+            LogEntry::User(_) => summary.user_count += 1,
+            LogEntry::Assistant(e) => {
+                summary.assistant_count += 1;
+                if let Some(msg) = &e.message {
+                    for block in &msg.content {
+                        // matches! 매크로는 패턴 매칭의 결과를 bool로 반환합니다.
+                        if matches!(block, ContentBlock::ToolUse { .. }) {
+                            summary.tool_use_count += 1;
+                        }
+                    }
+                    if let Some(usage) = &msg.usage {
+                        summary.total_input_tokens += usage.input_tokens;
+                        summary.total_output_tokens += usage.output_tokens;
+                        summary.total_cache_creation_tokens +=
+                            usage.cache_creation_input_tokens;
+                        summary.total_cache_read_tokens += usage.cache_read_input_tokens;
+                    }
+                }
+            }
+            LogEntry::Progress(_) => {}
+            _ => {}
+        }
+    }
+
+    // .into_values()는 HashMap에서 값(Value)만 추출하는 이터레이터를 반환합니다.
+    sessions.into_values().collect()
+}
+
+// === 단위 테스트 ===
+
+// #[cfg(test)]는 "cargo test 실행 시에만 컴파일"하라는 조건부 컴파일 속성입니다 (Rust Book Ch.11 참조).
+// mod tests는 테스트 전용 모듈을 정의합니다.
+#[cfg(test)]
+mod tests {
+    // super::*는 부모 모듈(claude.rs)의 모든 항목을 가져옵니다 (Rust Book Ch.7 참조).
+    use super::*;
+
+    // r#"..."#은 raw string literal입니다 — 이스케이프 없이 " 등을 포함할 수 있습니다 (Rust Book Ch.8 참조).
+    // 테스트에서는 unwrap()을 사용해도 됩니다 — 실패 시 panic으로 테스트가 실패 처리됩니다.
+
+    #[test]
+    fn test_parse_user_entry_returns_user_variant() {
+        let json = r#"{"type":"user","sessionId":"abc-12345","timestamp":"2026-03-11T13:06:07.215Z","uuid":"def-456","message":{"role":"user","content":"hello"}}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert!(matches!(entry, LogEntry::User(_)));
+    }
+
+    #[test]
+    fn test_parse_assistant_entry_with_text_content() {
+        let json = r#"{"type":"assistant","sessionId":"abc-12345","timestamp":"2026-03-11T13:06:11.990Z","uuid":"ghi-789","message":{"model":"claude-opus-4-6","role":"assistant","content":[{"type":"text","text":"Hello world"}],"usage":{"input_tokens":100,"output_tokens":50}}}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        if let LogEntry::Assistant(a) = entry {
+            let msg = a.message.unwrap();
+            assert_eq!(msg.content.len(), 1);
+            assert!(matches!(msg.content[0], ContentBlock::Text { .. }));
+            let usage = msg.usage.unwrap();
+            assert_eq!(usage.input_tokens, 100);
+            assert_eq!(usage.output_tokens, 50);
+        } else {
+            panic!("Expected Assistant entry");
+        }
+    }
+
+    #[test]
+    fn test_parse_assistant_entry_with_tool_use() {
+        let json = r#"{"type":"assistant","sessionId":"abc-12345","timestamp":"2026-03-11T13:06:11.990Z","uuid":"ghi-789","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","id":"toolu_123","input":{"file_path":"test.rs"}}]}}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        if let LogEntry::Assistant(a) = entry {
+            let msg = a.message.unwrap();
+            assert!(
+                matches!(&msg.content[0], ContentBlock::ToolUse { name, .. } if name.as_deref() == Some("Read"))
+            );
+        } else {
+            panic!("Expected Assistant entry");
+        }
+    }
+
+    #[test]
+    fn test_parse_progress_entry_returns_progress_variant() {
+        let json = r#"{"type":"progress","sessionId":"abc-12345","timestamp":"2026-03-11T13:06:12.895Z","uuid":"jkl-012","data":{"type":"hook_progress"}}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert!(matches!(entry, LogEntry::Progress(_)));
+    }
+
+    #[test]
+    fn test_parse_file_history_snapshot() {
+        let json = r#"{"type":"file-history-snapshot","messageId":"abc-123","snapshot":{"messageId":"abc-123","trackedFileBackups":{},"timestamp":"2026-03-11T13:06:07.216Z"},"isSnapshotUpdate":false}"#;
+        let entry: LogEntry = serde_json::from_str(json).unwrap();
+        assert!(matches!(entry, LogEntry::FileHistorySnapshot(_)));
+    }
+
+    #[test]
+    fn test_parse_invalid_json_returns_error() {
+        let bad_json = "this is not json";
+        let result = serde_json::from_str::<LogEntry>(bad_json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_summarize_entries_counts_messages() {
+        let entries = vec![
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"s1","timestamp":"2026-03-11T10:00:00Z","uuid":"u1"}"#,
+            )
+            .unwrap(),
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"s1","timestamp":"2026-03-11T10:01:00Z","uuid":"u2"}"#,
+            )
+            .unwrap(),
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"assistant","sessionId":"s1","timestamp":"2026-03-11T10:00:30Z","uuid":"a1","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+            )
+            .unwrap(),
+        ];
+        let summaries = summarize_entries(&entries);
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].user_count, 2);
+        assert_eq!(summaries[0].assistant_count, 1);
+        assert_eq!(summaries[0].total_input_tokens, 10);
+    }
+
+    #[test]
+    fn test_filter_entries_by_date_filters_correctly() {
+        let entries = vec![
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"s1","timestamp":"2026-03-11T10:00:00Z","uuid":"u1"}"#,
+            )
+            .unwrap(),
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"s1","timestamp":"2026-03-10T10:00:00Z","uuid":"u2"}"#,
+            )
+            .unwrap(),
+        ];
+        let date = NaiveDate::from_ymd_opt(2026, 3, 11).unwrap();
+        let filtered = filter_entries_by_date(entries, date);
+        assert_eq!(filtered.len(), 1);
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,19 @@
+// parser 모듈은 로그 파일을 읽고 구조화된 데이터로 변환하는 역할을 합니다.
+// 디렉토리 안에 mod.rs 파일을 두면 디렉토리 이름이 모듈 이름이 됩니다 (Rust Book Ch.7 참조).
+// 예: src/parser/mod.rs → mod parser; 로 선언 가능
+
+// claude 서브모듈을 공개(pub) 선언합니다.
+// 이렇게 하면 parser::claude::LogEntry 형태로 접근할 수 있습니다.
+pub mod claude;
+
+// Box<dyn std::error::Error>는 "어떤 에러든 담을 수 있는 박스"입니다.
+// dyn은 동적 디스패치를 의미합니다 — 런타임에 실제 에러 타입이 결정됩니다 (Rust Book Ch.17 참조).
+// M5에서 thiserror 크레이트로 전용 에러 타입을 만들 예정이므로, 지금은 이 간단한 별칭을 사용합니다.
+pub type ParseError = Box<dyn std::error::Error>;
+
+// pub use로 자주 사용하는 항목을 상위 모듈에서 바로 접근할 수 있게 합니다 (Rust Book Ch.7.4 참조).
+// 예: parser::LogEntry 로 바로 접근 가능 (parser::claude::LogEntry 대신)
+pub use claude::{
+    discover_log_dir, filter_entries_by_date, list_project_dirs, list_session_files,
+    parse_jsonl_file, summarize_entries,
+};


### PR DESCRIPTION
## 요약

- Claude Code JSONL 세션 로그를 파싱하여 구조화된 데이터로 변환
- 날짜 기반 필터링으로 오늘의 로그만 추출
- 세션별 통계 요약 (메시지 수, 툴 사용, 토큰 사용량)

## 변경 사항

- `Cargo.toml`: serde, serde_json, chrono, dirs 의존성 추가
- `src/parser/mod.rs`: parser 모듈 정의, ParseError 타입 별칭, re-exports
- `src/parser/claude.rs`: JSONL 파서 핵심 구현
  - 데이터 타입: `LogEntry`, `UserEntry`, `AssistantEntry`, `ContentBlock`, `Usage`, `SessionSummary`
  - 함수: `discover_log_dir`, `list_project_dirs`, `list_session_files`, `parse_jsonl_file`, `filter_entries_by_date`, `summarize_entries`
  - 단위 테스트 8개
- `src/main.rs`: `run_today()` 함수 구현 (로그 수집 → 필터링 → 요약 출력)

## 학습 포인트

- serde 역직렬화 (`Deserialize`, `#[serde(tag)]`, `#[serde(rename_all)]`)
- 소유권과 빌림 (`Vec<LogEntry>` 소유권 이동 vs `&[LogEntry]` 빌림)
- 이터레이터 체이닝 (`.into_iter().filter().collect()`)
- HashMap의 entry API (`.entry().or_insert_with()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)