### PR TITLE
feat: M4 Markdown 생성 및 Obsidian vault 저장

### DIFF
--- a/src/analyzer/client.rs
+++ b/src/analyzer/client.rs
@@ -16,25 +16,26 @@ const MODEL: &str = "claude-opus-4-6";
 const SYSTEM_PROMPT: &str = r#"You are an AI coding session analyst. You receive transcripts of conversations between a developer and an AI coding assistant.
 
 Analyze the conversation and extract insights in the following JSON format. Return ONLY valid JSON, no other text.
+IMPORTANT: All values MUST be written in Korean (한국어).
 
 {
   "sessions": [
     {
-      "session_id": "the session identifier",
-      "work_summary": "1-2 sentence summary of what was accomplished in this session",
+      "session_id": "the session identifier (keep original ID as-is)",
+      "work_summary": "이 세션에서 수행한 작업을 1-2문장으로 요약 (한국어)",
       "decisions": [
         {
-          "what": "description of the decision or choice point",
-          "why": "the reason the user chose this option"
+          "what": "결정 또는 선택 분기에 대한 설명 (한국어)",
+          "why": "사용자가 이 옵션을 선택한 이유 (한국어)"
         }
       ],
       "curiosities": [
-        "thing the user was curious about or confused by"
+        "사용자가 궁금했거나 헷갈렸던 것 (한국어)"
       ],
       "corrections": [
         {
-          "model_said": "what the AI said that was wrong",
-          "user_corrected": "what the user said to correct it"
+          "model_said": "AI가 틀리게 말한 내용 (한국어)",
+          "user_corrected": "사용자가 수정한 내용 (한국어)"
         }
       ]
     }
@@ -48,7 +49,8 @@ Rules:
 - For corrections: look for cases where the user pointed out an error in the AI's response, provided factual corrections, or disagreed with the AI's approach.
 - If a category has no items for a session, use an empty array.
 - work_summary should capture the main task or goal of the session.
-- Return ONLY the JSON object. Do not wrap it in markdown code fences."#;
+- Return ONLY the JSON object. Do not wrap it in markdown code fences.
+- ALL text values (except session_id) MUST be in Korean."#;
 
 // === API 요청/응답 타입 (이 모듈 내부에서만 사용) ===
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // Rust는 파일 하나가 모듈 하나에 대응됩니다 — cli.rs 파일이 cli 모듈이 됩니다 (Rust Book Ch.7 참조).
 mod analyzer;
 mod cli;
+mod output;
 mod parser;
 
 // use 키워드로 다른 모듈의 항목을 현재 스코프로 가져옵니다.
@@ -86,11 +87,51 @@ async fn run_today() -> Result<(), parser::ParseError> {
     // analyzer 실패 시에도 기존 요약은 이미 출력되었으므로 프로그램을 종료하지 않습니다.
     // match로 성공/실패를 명시적으로 처리합니다 (?로 전파하지 않음).
     match analyzer::analyze_entries(&all_entries).await {
-        Ok(analysis) => print_insights(&analysis),
+        Ok(analysis) => {
+            print_insights(&analysis);
+            // [M4] 분석 결과를 Markdown으로 변환하여 vault에 저장합니다.
+            save_analysis(&analysis, today);
+        }
         Err(e) => eprintln!("분석 실패: {e}"),
     }
 
     Ok(())
+}
+
+/// [M4] 분석 결과를 Markdown으로 변환하여 Obsidian vault에 저장합니다.
+///
+/// 각 단계에서 실패하면 에러를 출력하고 return합니다 — 프로그램을 중단하지 않습니다.
+/// vault 경로가 설정되지 않아도 터미널 출력(print_insights)은 이미 완료된 상태입니다.
+fn save_analysis(analysis: &analyzer::AnalysisResult, date: chrono::NaiveDate) {
+    let vault_path = match output::load_vault_path() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Vault 경로 로드 실패: {e}");
+            return;
+        }
+    };
+
+    let markdown = output::render_markdown(analysis, date);
+
+    // 저장할 파일 경로를 미리 계산하여 덮어쓰기 확인에 사용합니다.
+    let file_path = vault_path.join(format!("{date}.md"));
+
+    match output::confirm_overwrite(&file_path) {
+        Ok(true) => {} // 진행
+        Ok(false) => {
+            println!("저장을 건너뜁니다.");
+            return;
+        }
+        Err(e) => {
+            eprintln!("입력 읽기 실패: {e}");
+            return;
+        }
+    }
+
+    match output::save_to_vault(&vault_path, date, &markdown) {
+        Ok(saved) => println!("\nMarkdown 저장 완료: {}", saved.display()),
+        Err(e) => eprintln!("파일 저장 실패: {e}"),
+    }
 }
 
 /// 분석 결과를 터미널에 출력합니다.

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -1,0 +1,176 @@
+// AnalysisResult를 Markdown 문자열로 변환하는 모듈.
+//
+// I/O가 없는 순수 함수로 구성되어 단위 테스트가 쉽습니다.
+// format! 매크로와 String::push_str()로 문자열을 조립합니다 (Rust Book Ch.8.2 참조).
+
+use chrono::NaiveDate;
+
+use crate::analyzer::insight::{AnalysisResult, SessionInsight};
+
+/// AnalysisResult와 날짜를 받아 Markdown 문자열을 생성합니다.
+///
+/// String::new()는 빈 문자열을 힙에 할당합니다.
+/// push_str()은 문자열 슬라이스(&str)를 String 끝에 추가합니다 (Rust Book Ch.8.2 참조).
+/// format!은 포매팅된 새 String을 반환하는 매크로입니다.
+pub fn render_markdown(analysis: &AnalysisResult, date: NaiveDate) -> String {
+    let mut md = String::new();
+
+    // 제목 — NaiveDate는 Display 트레이트를 구현하여 "YYYY-MM-DD" 형식으로 출력됩니다.
+    md.push_str(&format!("# {date} Dev Session Review\n\n"));
+
+    // TIL 수집용 Vec — 모든 세션에서 curiosities와 corrections를 모읍니다.
+    let mut til_items: Vec<String> = Vec::new();
+
+    for session in &analysis.sessions {
+        render_session(&mut md, session, &mut til_items);
+    }
+
+    // TIL 섹션 — 전체 세션에서 수집한 학습 항목을 하나로 합칩니다.
+    render_til_section(&mut md, &til_items);
+
+    md
+}
+
+/// 세션 하나의 Markdown을 생성하고, TIL 항목도 수집합니다.
+///
+/// &mut String은 가변 참조로, 함수 안에서 문자열에 내용을 추가할 수 있습니다 (Rust Book Ch.4 참조).
+/// &mut Vec<String>도 마찬가지로 벡터에 항목을 추가할 수 있게 합니다.
+fn render_session(md: &mut String, session: &SessionInsight, til_items: &mut Vec<String>) {
+    md.push_str(&format!("## Session: {}\n\n", session.session_id));
+    md.push_str(&format!("### 작업 요약\n{}\n\n", session.work_summary));
+
+    // 비어있는 섹션은 출력하지 않습니다.
+    // .is_empty()는 Vec이나 String의 길이가 0인지 확인합니다.
+    if !session.decisions.is_empty() {
+        md.push_str("### 주요 의사결정\n");
+        for d in &session.decisions {
+            md.push_str(&format!("- **{}**: {}\n", d.what, d.why));
+        }
+        md.push('\n');
+    }
+
+    if !session.curiosities.is_empty() {
+        md.push_str("### 궁금했던 것 / 헷갈렸던 것\n");
+        for c in &session.curiosities {
+            md.push_str(&format!("- {c}\n"));
+            // TIL에도 추가 — 궁금했던 것은 배움의 시작점입니다.
+            til_items.push(c.clone());
+        }
+        md.push('\n');
+    }
+
+    if !session.corrections.is_empty() {
+        md.push_str("### 모델 오류 및 수정\n");
+        for c in &session.corrections {
+            md.push_str(&format!("- **모델**: {}\n  **수정**: {}\n", c.model_said, c.user_corrected));
+            // 모델 수정 사항도 학습 경험이므로 TIL에 추가합니다.
+            til_items.push(c.user_corrected.clone());
+        }
+        md.push('\n');
+    }
+
+    md.push_str("---\n\n");
+}
+
+/// TIL(Today I Learned) 섹션을 Markdown에 추가합니다.
+///
+/// Vec::dedup()는 연속된 중복 요소만 제거하므로, sort() 후 호출합니다 (Rust Book Ch.8.1 참조).
+fn render_til_section(md: &mut String, til_items: &[String]) {
+    if til_items.is_empty() {
+        return;
+    }
+
+    // 중복 제거를 위해 정렬 후 dedup합니다.
+    // .to_vec()로 소유권을 가진 복사본을 만듭니다 — 원본 슬라이스는 변경할 수 없기 때문입니다.
+    let mut unique_items = til_items.to_vec();
+    unique_items.sort();
+    unique_items.dedup();
+
+    md.push_str("## TIL (Today I Learned)\n");
+    for item in &unique_items {
+        md.push_str(&format!("- {item}\n"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyzer::insight::{Correction, Decision, SessionInsight};
+
+    /// 테스트용 AnalysisResult를 생성하는 헬퍼 함수.
+    /// 필드가 모두 pub이므로 구조체 리터럴로 직접 생성할 수 있습니다.
+    fn make_test_analysis() -> AnalysisResult {
+        AnalysisResult {
+            sessions: vec![SessionInsight {
+                session_id: "test-session-1".to_string(),
+                work_summary: "파서 모듈 구현".to_string(),
+                decisions: vec![Decision {
+                    what: "serde 사용".to_string(),
+                    why: "자동 역직렬화가 편리".to_string(),
+                }],
+                curiosities: vec!["serde의 tag 속성이란?".to_string()],
+                corrections: vec![],
+            }],
+        }
+    }
+
+    fn test_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 3, 11).expect("유효한 날짜")
+    }
+
+    #[test]
+    fn test_render_markdown_단일세션_제목과_요약_포함() {
+        let analysis = make_test_analysis();
+        let md = render_markdown(&analysis, test_date());
+
+        assert!(md.contains("# 2026-03-11 Dev Session Review"));
+        assert!(md.contains("## Session: test-session-1"));
+        assert!(md.contains("### 작업 요약\n파서 모듈 구현"));
+    }
+
+    #[test]
+    fn test_render_markdown_decisions_포함시_의사결정섹션_생성() {
+        let analysis = make_test_analysis();
+        let md = render_markdown(&analysis, test_date());
+
+        assert!(md.contains("### 주요 의사결정"));
+        assert!(md.contains("- **serde 사용**: 자동 역직렬화가 편리"));
+    }
+
+    #[test]
+    fn test_render_markdown_빈_decisions일때_의사결정섹션_미생성() {
+        let analysis = AnalysisResult {
+            sessions: vec![SessionInsight {
+                session_id: "s1".to_string(),
+                work_summary: "요약".to_string(),
+                decisions: vec![],
+                curiosities: vec![],
+                corrections: vec![],
+            }],
+        };
+        let md = render_markdown(&analysis, test_date());
+
+        assert!(!md.contains("### 주요 의사결정"));
+    }
+
+    #[test]
+    fn test_render_markdown_til_curiosities와_corrections에서_추출() {
+        let analysis = AnalysisResult {
+            sessions: vec![SessionInsight {
+                session_id: "s1".to_string(),
+                work_summary: "요약".to_string(),
+                decisions: vec![],
+                curiosities: vec!["궁금한 점".to_string()],
+                corrections: vec![Correction {
+                    model_said: "틀린 내용".to_string(),
+                    user_corrected: "올바른 내용".to_string(),
+                }],
+            }],
+        };
+        let md = render_markdown(&analysis, test_date());
+
+        assert!(md.contains("## TIL (Today I Learned)"));
+        assert!(md.contains("- 궁금한 점"));
+        assert!(md.contains("- 올바른 내용"));
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,119 @@
+// output 모듈은 분석 결과를 Markdown 파일로 변환하여 Obsidian vault에 저장하는 역할을 합니다.
+// parser, analyzer 모듈과 같은 디렉토리 구조를 사용합니다 (Rust Book Ch.7 참조).
+
+pub mod markdown;
+
+// M5에서 thiserror로 전용 에러 타입을 만들 예정입니다.
+pub type OutputError = Box<dyn std::error::Error>;
+
+pub use markdown::render_markdown;
+
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+/// Obsidian vault 경로를 환경 변수에서 읽습니다.
+///
+/// analyzer/mod.rs의 load_api_key()와 같은 패턴입니다:
+/// dotenvy로 .env 파일을 로드한 뒤, std::env::var()로 환경 변수를 읽습니다.
+///
+/// PathBuf는 소유권을 가진 경로 타입입니다 — String이 &str의 소유 버전인 것처럼,
+/// PathBuf는 &Path의 소유 버전입니다 (Rust Book Ch.12 참조).
+/// PathBuf::from()은 문자열을 OS 경로로 변환합니다.
+pub fn load_vault_path() -> Result<PathBuf, OutputError> {
+    // .env 파일이 있으면 로드, 없으면 무시 — 환경 변수가 직접 설정된 경우를 지원합니다.
+    dotenvy::dotenv().ok();
+
+    let path_str = std::env::var("RWD_VAULT_PATH").map_err(|_| {
+        "RWD_VAULT_PATH가 설정되지 않았습니다. \
+         .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
+         예: echo 'RWD_VAULT_PATH=/path/to/obsidian/vault' >> .env"
+    })?;
+
+    let path = PathBuf::from(&path_str);
+
+    // .exists()와 .is_dir()는 파일 시스템을 조회하여 경로 상태를 확인합니다.
+    if !path.exists() {
+        return Err(format!("Vault 경로가 존재하지 않습니다: {}", path.display()).into());
+    }
+    if !path.is_dir() {
+        return Err(format!("Vault 경로가 디렉토리가 아닙니다: {}", path.display()).into());
+    }
+
+    Ok(path)
+}
+
+/// 날짜 기반 파일명으로 Markdown 내용을 vault에 저장합니다.
+///
+/// Path::join()은 경로와 파일명을 결합하여 새 PathBuf를 반환합니다 (Rust Book Ch.12 참조).
+/// std::fs::write()는 파일 내용 전체를 한 번에 기록합니다 — 파일이 없으면 생성하고, 있으면 덮어씁니다.
+pub fn save_to_vault(
+    vault_path: &Path,
+    date: NaiveDate,
+    content: &str,
+) -> Result<PathBuf, OutputError> {
+    // 파일명: "2026-03-11.md" — NaiveDate의 Display 트레이트가 "YYYY-MM-DD" 형식을 제공합니다.
+    let filename = format!("{date}.md");
+    // .join()은 OS에 맞는 경로 구분자로 결합합니다 (Windows: \, Unix: /).
+    let file_path = vault_path.join(&filename);
+
+    std::fs::write(&file_path, content)?;
+
+    Ok(file_path)
+}
+
+/// 파일이 이미 존재할 때 사용자에게 덮어쓸지 확인합니다.
+///
+/// std::io::stdin().read_line()은 사용자의 키보드 입력을 한 줄 읽습니다 (Rust Book Ch.2 참조).
+/// &mut input은 가변 참조로, read_line이 input 변수에 입력 내용을 기록할 수 있게 합니다.
+/// 반환값 Result<usize, io::Error>에서 usize는 읽은 바이트 수입니다.
+pub fn confirm_overwrite(path: &Path) -> Result<bool, OutputError> {
+    // 파일이 없으면 확인 불필요 — 바로 저장 진행
+    if !path.exists() {
+        return Ok(true);
+    }
+
+    // eprintln!은 stderr에 출력합니다 — 프롬프트 메시지는 데이터 출력(stdout)과 분리하는 것이 CLI 관례입니다.
+    eprint!(
+        "파일이 이미 존재합니다: {}\n덮어쓰시겠습니까? (y/N): ",
+        path.display()
+    );
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+
+    // .trim()은 양끝 공백과 개행 문자를 제거합니다.
+    // .to_lowercase()는 대소문자를 통일하여 "Y", "y", "YES" 등을 모두 처리합니다.
+    let answer = input.trim().to_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_save_to_vault_파일생성_확인() {
+        // std::env::temp_dir()는 OS의 임시 디렉토리 경로를 반환합니다.
+        // 테스트 격리를 위해 고유한 하위 디렉토리를 만듭니다.
+        let temp_dir = std::env::temp_dir().join("rwd_test_output");
+        std::fs::create_dir_all(&temp_dir).expect("임시 디렉토리 생성 실패");
+
+        let date = NaiveDate::from_ymd_opt(2026, 3, 11).expect("유효한 날짜");
+        let content = "# 테스트 Markdown";
+
+        let result = save_to_vault(&temp_dir, date, content);
+        assert!(result.is_ok());
+
+        let saved_path = result.expect("저장 성공");
+        assert!(saved_path.exists());
+        assert_eq!(
+            std::fs::read_to_string(&saved_path).expect("파일 읽기"),
+            content
+        );
+
+        // 테스트 후 정리 — 생성한 파일과 디렉토리를 삭제합니다.
+        std::fs::remove_file(&saved_path).ok();
+        std::fs::remove_dir(&temp_dir).ok();
+    }
+}


### PR DESCRIPTION
## Summary
- `src/output/` 모듈 신규 생성: AnalysisResult → Markdown 변환, vault 경로 로딩, 파일 저장, 덮어쓰기 확인
- `rwd today` 전체 파이프라인 연결: 로그 파싱 → API 호출 → Markdown 생성 → Obsidian vault 저장
- LLM 시스템 프롬프트를 한국어 응답으로 변경

## Test plan
- [x] `cargo build` 통과
- [x] `cargo clippy` 경고 0개
- [x] `cargo test` 21개 전체 통과 (기존 15 + 신규 6)
- [x] `.env`에 `RWD_VAULT_PATH` 설정 후 `cargo run -- today` 실행하여 `.md` 파일 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)