### PR TITLE
feat: LLM 멀티 프로바이더 지원 (Anthropic + OpenAI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,8 @@
+# LLM 프로바이더 선택 (anthropic 또는 openai, 기본값: anthropic)
+# LLM_PROVIDER=anthropic
+
+# Anthropic Claude API 키
 ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# OpenAI API 키 (LLM_PROVIDER=openai 사용 시 필요)
+# OPENAI_API_KEY=sk-your-key-here

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,12 @@ rwd/
 │   │   ├── mod.rs
 │   │   └── claude.rs      # Claude Code 로그 파서
 │   ├── analyzer/          # 구조화된 데이터 → LLM 인사이트 추출
-│   │   └── mod.rs
+│   │   ├── mod.rs         # 오케스트레이터
+│   │   ├── provider.rs    # LlmProvider enum, 프로바이더 선택
+│   │   ├── anthropic.rs   # Anthropic Claude API 클라이언트
+│   │   ├── openai.rs      # OpenAI API 클라이언트
+│   │   ├── insight.rs     # 응답 파싱
+│   │   └── prompt.rs      # 프롬프트 생성
 │   ├── output/            # Markdown 생성 및 파일 저장
 │   │   └── mod.rs
 │   └── config.rs          # 설정 (경로, API 키 등)

--- a/src/analyzer/anthropic.rs
+++ b/src/analyzer/anthropic.rs
@@ -1,4 +1,4 @@
-// Claude Messages API HTTP 클라이언트.
+// Anthropic Claude Messages API 클라이언트.
 //
 // reqwest 크레이트로 비동기 HTTP 요청을 보냅니다.
 // async/await 패턴으로 네트워크 I/O 동안 스레드를 차단하지 않습니다.
@@ -12,45 +12,7 @@ const API_VERSION: &str = "2023-06-01";
 // 분석에 사용할 모델 (M5에서 설정 파일로 변경 예정)
 const MODEL: &str = "claude-opus-4-6";
 
-/// 시스템 프롬프트 — LLM에게 인사이트 추출 방법과 JSON 응답 형식을 지시합니다.
-const SYSTEM_PROMPT: &str = r#"You are an AI coding session analyst. You receive transcripts of conversations between a developer and an AI coding assistant.
-
-Analyze the conversation and extract insights in the following JSON format. Return ONLY valid JSON, no other text.
-IMPORTANT: All values MUST be written in Korean (한국어).
-
-{
-  "sessions": [
-    {
-      "session_id": "the session identifier (keep original ID as-is)",
-      "work_summary": "이 세션에서 수행한 작업을 1-2문장으로 요약 (한국어)",
-      "decisions": [
-        {
-          "what": "결정 또는 선택 분기에 대한 설명 (한국어)",
-          "why": "사용자가 이 옵션을 선택한 이유 (한국어)"
-        }
-      ],
-      "curiosities": [
-        "사용자가 궁금했거나 헷갈렸던 것 (한국어)"
-      ],
-      "corrections": [
-        {
-          "model_said": "AI가 틀리게 말한 내용 (한국어)",
-          "user_corrected": "사용자가 수정한 내용 (한국어)"
-        }
-      ]
-    }
-  ]
-}
-
-Rules:
-- Each session_id in the transcript should have its own entry in the sessions array.
-- For decisions: look for moments where the user chose between alternatives, rejected a suggestion, or stated a preference.
-- For curiosities: look for questions the user asked, concepts they wanted explained, or things they expressed uncertainty about.
-- For corrections: look for cases where the user pointed out an error in the AI's response, provided factual corrections, or disagreed with the AI's approach.
-- If a category has no items for a session, use an empty array.
-- work_summary should capture the main task or goal of the session.
-- Return ONLY the JSON object. Do not wrap it in markdown code fences.
-- ALL text values (except session_id) MUST be in Korean."#;
+// SYSTEM_PROMPT는 provider.rs로 이동했습니다 — 모든 프로바이더가 공유하는 상수입니다.
 
 // === API 요청/응답 타입 (이 모듈 내부에서만 사용) ===
 
@@ -87,7 +49,7 @@ struct ApiContentBlock {
     text: Option<String>,
 }
 
-/// Claude Messages API를 호출하여 원시 텍스트 응답을 반환합니다.
+/// Anthropic Claude Messages API를 호출하여 원시 텍스트 응답을 반환합니다.
 ///
 /// reqwest::Client는 HTTP 클라이언트입니다 — 빌더 패턴으로 요청을 구성합니다.
 /// .post(url): POST 요청 생성
@@ -95,8 +57,9 @@ struct ApiContentBlock {
 /// .json(&body): 구조체를 JSON으로 직렬화하여 요청 본문에 설정 (serde::Serialize 필요)
 /// .send().await: 비동기로 요청을 보내고 응답을 기다림
 /// .error_for_status(): HTTP 상태 코드가 4xx/5xx이면 Err로 변환
-pub async fn call_claude_api(
+pub async fn call_anthropic_api(
     api_key: &str,
+    system_prompt: &str,
     conversation_text: &str,
 ) -> Result<String, super::AnalyzerError> {
     let client = reqwest::Client::new();
@@ -104,7 +67,7 @@ pub async fn call_claude_api(
     let request_body = ApiRequest {
         model: MODEL.to_string(),
         max_tokens: 4096,
-        system: SYSTEM_PROMPT.to_string(),
+        system: system_prompt.to_string(),
         messages: vec![ApiMessage {
             role: "user".to_string(),
             content: conversation_text.to_string(),

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,9 +1,12 @@
-// analyzer 모듈은 파싱된 로그 데이터를 Claude API에 보내 인사이트를 추출하는 역할을 합니다.
+// analyzer 모듈은 파싱된 로그 데이터를 LLM API에 보내 인사이트를 추출하는 역할을 합니다.
+// provider.rs의 LlmProvider enum으로 Anthropic, OpenAI 등 여러 프로바이더를 지원합니다.
 // parser 모듈과 같은 디렉토리 구조를 사용합니다 (Rust Book Ch.7 참조).
 
-pub mod client;
+pub mod anthropic;
 pub mod insight;
+pub mod openai;
 pub mod prompt;
+pub mod provider;
 
 // parser 모듈과 동일한 에러 타입 패턴을 사용합니다.
 // M5에서 thiserror로 전용 에러 타입을 만들 예정입니다.
@@ -20,28 +23,14 @@ use crate::parser::claude::LogEntry;
 /// async fn은 비동기 함수를 선언합니다 (tokio 런타임 위에서 실행).
 /// 네트워크 I/O(API 호출) 동안 다른 작업을 처리할 수 있게 해줍니다.
 /// 호출 시 .await를 붙여야 실제로 실행됩니다 (Rust Async Book 참조).
+///
+/// provider::load_provider()로 프로바이더와 API 키를 읽고,
+/// provider.call_api()로 선택된 프로바이더의 API를 호출합니다.
+/// 이 함수 자체는 어떤 프로바이더가 사용되는지 알 필요가 없습니다.
 pub async fn analyze_entries(entries: &[LogEntry]) -> Result<AnalysisResult, AnalyzerError> {
-    let api_key = load_api_key()?;
+    let (provider, api_key) = provider::load_provider()?;
     let prompt_text = prompt::build_prompt(entries)?;
-    let raw_response = client::call_claude_api(&api_key, &prompt_text).await?;
+    let raw_response = provider.call_api(&api_key, &prompt_text).await?;
     let result = insight::parse_response(&raw_response)?;
     Ok(result)
-}
-
-/// ANTHROPIC_API_KEY를 .env 파일 또는 환경 변수에서 읽습니다.
-///
-/// dotenvy::dotenv()는 프로젝트 루트의 .env 파일을 읽어 환경 변수로 등록합니다.
-/// .ok()로 파일이 없어도 에러 없이 넘어갑니다 — 환경 변수가 직접 설정된 경우를 지원합니다.
-/// std::env::var()는 환경 변수를 읽어 Result<String, VarError>를 반환합니다.
-/// .map_err()로 에러 메시지를 사용자 친화적으로 변환합니다 (Rust Book Ch.9 참조).
-fn load_api_key() -> Result<String, AnalyzerError> {
-    // .env 파일이 있으면 로드, 없으면 무시
-    dotenvy::dotenv().ok();
-
-    std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
-        "ANTHROPIC_API_KEY가 설정되지 않았습니다. \
-         .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
-         예: echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env"
-            .into()
-    })
 }

--- a/src/analyzer/openai.rs
+++ b/src/analyzer/openai.rs
@@ -1,0 +1,159 @@
+// OpenAI Chat Completions API 클라이언트.
+//
+// Anthropic과 같은 reqwest + serde 패턴을 사용하지만, 요청/응답 JSON 스키마가 다릅니다.
+// 주요 차이점:
+// - 인증: Authorization: Bearer <key> (Anthropic은 x-api-key 헤더)
+// - system prompt: messages 배열의 {"role": "system"} 메시지 (Anthropic은 top-level system 필드)
+// - 응답: choices[0].message.content (Anthropic은 content[0].text)
+
+use serde::{Deserialize, Serialize};
+
+// OpenAI Chat Completions 엔드포인트
+const API_URL: &str = "https://api.openai.com/v1/chat/completions";
+// 분석에 사용할 모델 (M5에서 설정 파일로 변경 예정)
+const MODEL: &str = "gpt-4o";
+
+// === API 요청/응답 타입 (이 모듈 내부에서만 사용) ===
+
+/// OpenAI Chat Completions 요청 본문.
+/// Anthropic의 ApiRequest와 비교하면:
+/// - system 필드가 없음 → system prompt를 messages 배열에 포함
+/// - messages 배열에 role: "system", "user" 등 여러 역할의 메시지를 넣음
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_tokens: u32,
+}
+
+/// Chat 메시지 (role + content).
+/// Anthropic의 ApiMessage와 동일한 구조이지만, role에 "system"도 가능합니다.
+#[derive(Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+/// OpenAI Chat Completions 응답 본문.
+/// Anthropic은 content 배열을 사용하지만, OpenAI는 choices 배열을 사용합니다.
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+/// choices 배열의 각 항목.
+/// index, message, finish_reason을 포함하지만, 우리는 message.content만 사용합니다.
+#[derive(Deserialize)]
+struct Choice {
+    message: ChoiceMessage,
+}
+
+/// choice 내부의 메시지.
+/// role은 항상 "assistant"이고, content에 LLM 응답 텍스트가 들어 있습니다.
+#[derive(Deserialize)]
+struct ChoiceMessage {
+    content: String,
+}
+
+/// OpenAI Chat Completions API를 호출하여 원시 텍스트 응답을 반환합니다.
+///
+/// anthropic.rs의 call_anthropic_api()와 동일한 역할을 하지만:
+/// - Authorization: Bearer 헤더로 인증합니다 (Anthropic은 x-api-key)
+/// - system prompt를 messages 배열의 첫 번째 메시지로 전달합니다
+/// - 응답에서 choices[0].message.content를 추출합니다
+pub async fn call_openai_api(
+    api_key: &str,
+    system_prompt: &str,
+    conversation_text: &str,
+) -> Result<String, super::AnalyzerError> {
+    let client = reqwest::Client::new();
+
+    // OpenAI는 system prompt를 messages 배열에 {"role": "system"} 메시지로 전달합니다.
+    // Anthropic은 top-level system 필드를 사용하는 것과 대조적입니다.
+    let request_body = ChatRequest {
+        model: MODEL.to_string(),
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: system_prompt.to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: conversation_text.to_string(),
+            },
+        ],
+        max_tokens: 4096,
+    };
+
+    // Authorization: Bearer 헤더 — OpenAI의 인증 방식입니다.
+    // format!()으로 문자열을 조합합니다 (Rust Book Ch.8.2 참조).
+    let response = client
+        .post(API_URL)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .send()
+        .await?;
+
+    // anthropic.rs와 동일한 에러 처리 패턴
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await.unwrap_or_default();
+        return Err(format!("OpenAI API 요청 실패 ({status}): {error_body}").into());
+    }
+
+    let chat_response: ChatResponse = response.json().await?;
+
+    // choices 배열의 첫 번째 항목에서 content를 추출합니다.
+    // .first()는 슬라이스의 첫 번째 요소를 Option으로 반환합니다 (Rust Book Ch.8.1).
+    let text = chat_response
+        .choices
+        .first()
+        .ok_or("OpenAI 응답에 choices가 비어 있습니다")?;
+
+    Ok(text.message.content.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// OpenAI 응답 JSON을 올바르게 파싱하는지 테스트합니다.
+    /// 실제 API 호출 없이 응답 파싱 로직만 검증합니다.
+    #[test]
+    fn test_parse_openai_response() {
+        let json = r#"{
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "{\"sessions\": []}"
+                    },
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 11,
+                "total_tokens": 21
+            }
+        }"#;
+
+        let response: ChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.choices.len(), 1);
+        assert_eq!(response.choices[0].message.content, "{\"sessions\": []}");
+    }
+
+    /// choices가 빈 배열인 경우 .first()가 None을 반환하는지 확인합니다.
+    #[test]
+    fn test_empty_choices() {
+        let json = r#"{"choices": []}"#;
+        let response: ChatResponse = serde_json::from_str(json).unwrap();
+        assert!(response.choices.first().is_none());
+    }
+}

--- a/src/analyzer/provider.rs
+++ b/src/analyzer/provider.rs
@@ -1,0 +1,128 @@
+// LLM 프로바이더 추상화 모듈.
+//
+// LlmProvider enum으로 여러 LLM API를 통합합니다.
+// enum + match 패턴은 LogEntry, Commands와 동일한 방식입니다 (Rust Book Ch.6 참조).
+// Anthropic과 OpenAI를 지원하며, 환경 변수로 프로바이더를 선택합니다.
+
+/// 시스템 프롬프트 — 모든 프로바이더가 공유합니다.
+/// 프로바이더에 관계없이 동일한 분석 지시를 전달합니다.
+pub const SYSTEM_PROMPT: &str = r#"You are an AI coding session analyst. You receive transcripts of conversations between a developer and an AI coding assistant.
+
+Analyze the conversation and extract insights in the following JSON format. Return ONLY valid JSON, no other text.
+IMPORTANT: All values MUST be written in Korean (한국어).
+
+{
+  "sessions": [
+    {
+      "session_id": "the session identifier (keep original ID as-is)",
+      "work_summary": "이 세션에서 수행한 작업을 1-2문장으로 요약 (한국어)",
+      "decisions": [
+        {
+          "what": "결정 또는 선택 분기에 대한 설명 (한국어)",
+          "why": "사용자가 이 옵션을 선택한 이유 (한국어)"
+        }
+      ],
+      "curiosities": [
+        "사용자가 궁금했거나 헷갈렸던 것 (한국어)"
+      ],
+      "corrections": [
+        {
+          "model_said": "AI가 틀리게 말한 내용 (한국어)",
+          "user_corrected": "사용자가 수정한 내용 (한국어)"
+        }
+      ]
+    }
+  ]
+}
+
+Rules:
+- Each session_id in the transcript should have its own entry in the sessions array.
+- For decisions: look for moments where the user chose between alternatives, rejected a suggestion, or stated a preference.
+- For curiosities: look for questions the user asked, concepts they wanted explained, or things they expressed uncertainty about.
+- For corrections: look for cases where the user pointed out an error in the AI's response, provided factual corrections, or disagreed with the AI's approach.
+- If a category has no items for a session, use an empty array.
+- work_summary should capture the main task or goal of the session.
+- Return ONLY the JSON object. Do not wrap it in markdown code fences.
+- ALL text values (except session_id) MUST be in Korean."#;
+
+/// LLM 프로바이더를 나타내는 enum.
+///
+/// enum은 "이것 또는 저것" 중 하나의 값을 표현합니다 (Rust Book Ch.6.1).
+/// 각 변형(variant)은 서로 다른 프로바이더에 대응합니다.
+/// match 표현식으로 모든 변형을 처리해야 컴파일됩니다 — 새 프로바이더 추가 시
+/// 컴파일러가 처리하지 않은 곳을 자동으로 알려줍니다.
+pub enum LlmProvider {
+    Anthropic,
+    OpenAi,
+}
+
+impl LlmProvider {
+    /// 선택된 프로바이더의 API를 호출하여 원시 텍스트 응답을 반환합니다.
+    ///
+    /// &self는 이 메서드가 LlmProvider 값의 참조를 받는다는 의미입니다.
+    /// match self로 어떤 프로바이더인지 확인하고, 해당 모듈의 함수를 호출합니다.
+    pub async fn call_api(
+        &self,
+        api_key: &str,
+        conversation_text: &str,
+    ) -> Result<String, super::AnalyzerError> {
+        match self {
+            LlmProvider::Anthropic => {
+                super::anthropic::call_anthropic_api(api_key, SYSTEM_PROMPT, conversation_text)
+                    .await
+            }
+            LlmProvider::OpenAi => {
+                super::openai::call_openai_api(api_key, SYSTEM_PROMPT, conversation_text).await
+            }
+        }
+    }
+
+    /// 프로바이더의 표시 이름을 반환합니다.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            LlmProvider::Anthropic => "Claude",
+            LlmProvider::OpenAi => "OpenAI",
+        }
+    }
+}
+
+/// 환경 변수에서 LLM 프로바이더와 API 키를 읽습니다.
+///
+/// dotenvy::dotenv()로 .env 파일을 로드한 뒤,
+/// LLM_PROVIDER 환경 변수로 프로바이더를 선택합니다.
+/// 설정되지 않은 경우 기본값 "anthropic"을 사용합니다 (하위 호환성).
+///
+/// 반환: (프로바이더, API 키) 튜플.
+/// 튜플은 서로 다른 타입의 값을 묶는 간단한 방법입니다 (Rust Book Ch.3.2).
+pub fn load_provider() -> Result<(LlmProvider, String), super::AnalyzerError> {
+    dotenvy::dotenv().ok();
+
+    // unwrap_or_else: Result가 Err일 때 클로저를 실행하여 기본값을 생성합니다.
+    // 여기서는 LLM_PROVIDER가 없으면 "anthropic"을 기본값으로 사용합니다.
+    let provider_name = std::env::var("LLM_PROVIDER")
+        .unwrap_or_else(|_| "anthropic".to_string());
+
+    match provider_name.as_str() {
+        "anthropic" => {
+            let key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+                "ANTHROPIC_API_KEY가 설정되지 않았습니다. \
+                 .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
+                 예: echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env"
+            })?;
+            Ok((LlmProvider::Anthropic, key))
+        }
+        "openai" => {
+            let key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+                "OPENAI_API_KEY가 설정되지 않았습니다. \
+                 .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
+                 예: echo 'OPENAI_API_KEY=sk-...' > .env"
+            })?;
+            Ok((LlmProvider::OpenAi, key))
+        }
+        other => Err(format!(
+            "지원하지 않는 LLM 프로바이더입니다: '{other}'. \
+             사용 가능: anthropic, openai"
+        )
+        .into()),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,12 @@ async fn run_today() -> Result<(), parser::ParseError> {
         );
     }
 
-    // LLM 분석 수행
-    println!("\nClaude API로 인사이트 분석 중...");
+    // LLM 분석 수행 — provider::load_provider()가 프로바이더 선택과 API 키 로딩을 담당합니다.
+    // 여기서는 표시 이름만 읽어 사용자에게 어떤 프로바이더가 사용되는지 알려줍니다.
+    let provider_label = analyzer::provider::load_provider()
+        .map(|(p, _)| p.display_name().to_string())
+        .unwrap_or_else(|_| "LLM".to_string());
+    println!("\n{provider_label} API로 인사이트 분석 중...");
     // analyzer 실패 시에도 기존 요약은 이미 출력되었으므로 프로그램을 종료하지 않습니다.
     // match로 성공/실패를 명시적으로 처리합니다 (?로 전파하지 않음).
     match analyzer::analyze_entries(&all_entries).await {


### PR DESCRIPTION
## Summary
- `analyzer/client.rs`를 `provider.rs` + `anthropic.rs` + `openai.rs`로 모듈화
- `LlmProvider` enum 기반 디스패치로 Anthropic/OpenAI 프로바이더 전환 지원
- `LLM_PROVIDER` 환경변수로 선택 (기본값: `anthropic` — 하위 호환)

## 변경 파일
| 파일 | 변경 |
|------|------|
| `src/analyzer/provider.rs` | **신규** — LlmProvider enum, SYSTEM_PROMPT, load_provider() |
| `src/analyzer/openai.rs` | **신규** — OpenAI Chat Completions API 클라이언트 |
| `src/analyzer/anthropic.rs` | `client.rs` 리네임 + system_prompt 파라미터화 |
| `src/analyzer/mod.rs` | provider 기반으로 리팩토링 |
| `src/main.rs` | 프로바이더명 동적 표시 |
| `.env.example` | LLM_PROVIDER, OPENAI_API_KEY 추가 |
| `docs/ARCHITECTURE.md` | analyzer 모듈 구조 업데이트 |

## 사용 방법
```bash
# 기본 (Anthropic) — 기존과 동일
ANTHROPIC_API_KEY=sk-ant-... rwd today

# OpenAI 사용
LLM_PROVIDER=openai OPENAI_API_KEY=sk-... rwd today
```

## Test plan
- [x] `cargo build` 통과
- [x] `cargo clippy` 경고 없음
- [x] `cargo test` 23개 전체 통과 (openai 파싱 테스트 2개 포함)
- [ ] `LLM_PROVIDER` 미설정 시 기본 Anthropic 동작 확인
- [ ] `LLM_PROVIDER=openai` + `OPENAI_API_KEY` 설정 시 OpenAI 호출 확인
- [ ] `LLM_PROVIDER=unknown` 시 에러 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)