### PR TITLE
chore: M5 config 시스템 — dev → main 승격

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
-dotenvy = "0.15"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+toml = "0.8"

--- a/src/analyzer/provider.rs
+++ b/src/analyzer/provider.rs
@@ -86,43 +86,23 @@ impl LlmProvider {
     }
 }
 
-/// 환경 변수에서 LLM 프로바이더와 API 키를 읽습니다.
-///
-/// dotenvy::dotenv()로 .env 파일을 로드한 뒤,
-/// LLM_PROVIDER 환경 변수로 프로바이더를 선택합니다.
-/// 설정되지 않은 경우 기본값 "anthropic"을 사용합니다 (하위 호환성).
+/// 설정 파일(~/.config/rwd/config.toml)에서 LLM 프로바이더와 API 키를 읽습니다.
 ///
 /// 반환: (프로바이더, API 키) 튜플.
 /// 튜플은 서로 다른 타입의 값을 묶는 간단한 방법입니다 (Rust Book Ch.3.2).
 pub fn load_provider() -> Result<(LlmProvider, String), super::AnalyzerError> {
-    dotenvy::dotenv().ok();
+    let config = crate::config::load_config_if_exists().ok_or_else(|| {
+        let hint = if std::path::Path::new(".env").exists() {
+            " (기존 .env 사용자: `rwd init`으로 설정을 마이그레이션하세요)"
+        } else {
+            ""
+        };
+        format!("설정 파일이 없습니다. `rwd init`을 먼저 실행해 주세요.{hint}")
+    })?;
 
-    // unwrap_or_else: Result가 Err일 때 클로저를 실행하여 기본값을 생성합니다.
-    // 여기서는 LLM_PROVIDER가 없으면 "anthropic"을 기본값으로 사용합니다.
-    let provider_name = std::env::var("LLM_PROVIDER")
-        .unwrap_or_else(|_| "anthropic".to_string());
-
-    match provider_name.as_str() {
-        "anthropic" => {
-            let key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
-                "ANTHROPIC_API_KEY가 설정되지 않았습니다. \
-                 .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
-                 예: echo 'ANTHROPIC_API_KEY=sk-ant-...' > .env"
-            })?;
-            Ok((LlmProvider::Anthropic, key))
-        }
-        "openai" => {
-            let key = std::env::var("OPENAI_API_KEY").map_err(|_| {
-                "OPENAI_API_KEY가 설정되지 않았습니다. \
-                 .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
-                 예: echo 'OPENAI_API_KEY=sk-...' > .env"
-            })?;
-            Ok((LlmProvider::OpenAi, key))
-        }
-        other => Err(format!(
-            "지원하지 않는 LLM 프로바이더입니다: '{other}'. \
-             사용 가능: anthropic, openai"
-        )
-        .into()),
-    }
+    let provider = match config.llm.provider.as_str() {
+        "openai" => LlmProvider::OpenAi,
+        _ => LlmProvider::Anthropic,
+    };
+    Ok((provider, config.llm.api_key))
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,4 +19,13 @@ pub struct Cli {
 pub enum Commands {
     /// 오늘의 세션 로그를 분석합니다
     Today,
+    /// 초기 설정을 수행합니다 (API 키, 출력 경로)
+    Init,
+    /// 설정 값을 변경합니다
+    Config {
+        /// 설정 키 (output-path, provider, api-key)
+        key: String,
+        /// 설정할 값
+        value: String,
+    },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,290 @@
+// config 모듈은 설정 파일(~/.config/rwd/config.toml)의 읽기/쓰기를 담당합니다.
+// 기존 .env 방식을 대체하여, rwd init / rwd config 커맨드로 설정을 관리합니다.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// M5에서 thiserror로 전환 예정이지만, 기존 모듈과 동일한 에러 타입 패턴을 사용합니다.
+pub type ConfigError = Box<dyn std::error::Error>;
+
+/// 설정 파일의 최상위 구조체.
+/// Serialize/Deserialize derive로 TOML ↔ Rust 구조체 자동 변환 (serde 패턴).
+/// Serialize는 Rust → TOML 변환, Deserialize는 TOML → Rust 변환을 담당합니다.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub llm: LlmConfig,
+    pub output: OutputConfig,
+}
+
+/// LLM 프로바이더 관련 설정.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LlmConfig {
+    pub provider: String,
+    pub api_key: String,
+}
+
+/// Markdown 출력 관련 설정.
+/// path는 vault root 경로를 저장합니다 — Daily/ 하위 디렉토리는 save_to_vault()가 붙입니다.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OutputConfig {
+    pub path: String,
+}
+
+/// 설정 파일 경로를 반환합니다: ~/.config/rwd/config.toml
+/// dirs::home_dir()로 홈 디렉토리를 찾고, Unix 관례에 맞게 ~/.config를 사용합니다.
+pub fn config_path() -> Result<PathBuf, ConfigError> {
+    let home = dirs::home_dir()
+        .ok_or("홈 디렉토리를 찾을 수 없습니다")?;
+    Ok(home.join(".config").join("rwd").join("config.toml"))
+}
+
+/// 설정을 TOML 파일로 저장합니다.
+/// toml::to_string_pretty()는 Config 구조체를 읽기 좋은 TOML 문자열로 변환합니다.
+/// create_dir_all()로 부모 디렉토리가 없으면 자동 생성합니다.
+pub fn save_config(config: &Config, path: &std::path::Path) -> Result<(), ConfigError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let toml_str = toml::to_string_pretty(config)?;
+    std::fs::write(path, toml_str)?;
+
+    // API 키가 포함된 파일이므로 소유자만 읽기/쓰기 가능하도록 권한 설정합니다.
+    // Unix 권한 0o600 = owner read+write only (보안 관례).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+/// TOML 파일에서 설정을 읽습니다.
+/// toml::from_str()는 TOML 문자열을 Config 구조체로 역직렬화합니다.
+pub fn load_config(path: &std::path::Path) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)?;
+    let config: Config = toml::from_str(&content)?;
+    Ok(config)
+}
+
+/// 설정 파일을 읽습니다. 파일이 없으면 None을 반환합니다.
+/// 호출부에서 None일 때 기존 .env fallback을 사용합니다.
+pub fn load_config_if_exists() -> Option<Config> {
+    let path = config_path().ok()?;
+    if path.exists() {
+        load_config(&path).ok()
+    } else {
+        None
+    }
+}
+
+/// rwd init 실행 — API 키를 입력받고, 출력 경로를 자동 감지하여 설정 파일에 저장합니다.
+///
+/// eprint!는 stderr로 프롬프트를 출력합니다 — stdout은 데이터 출력용으로 분리합니다.
+/// stdin().read_line()은 사용자 입력을 한 줄 읽습니다 (Rust Book Ch.2 참조).
+pub fn run_init() -> Result<(), ConfigError> {
+    let config_file = config_path()?;
+
+    // 기존 .env 파일이 있으면 마이그레이션 안내
+    let cwd_env = std::path::Path::new(".env");
+    if cwd_env.exists() {
+        eprintln!("기존 .env 파일이 감지되었습니다.");
+        eprintln!("rwd init 완료 후 .env 파일은 더 이상 사용되지 않습니다.");
+        eprintln!("설정은 ~/.config/rwd/config.toml에서 관리됩니다.\n");
+    }
+
+    // 프로바이더 선택
+    eprint!("LLM 프로바이더를 선택하세요 (anthropic/openai) [anthropic]: ");
+    let mut provider_input = String::new();
+    std::io::stdin().read_line(&mut provider_input)?;
+    let provider = provider_input.trim();
+    let provider = if provider.is_empty() { "anthropic" } else { provider };
+
+    // 프로바이더 검증
+    if !["anthropic", "openai"].contains(&provider) {
+        return Err(format!("지원하지 않는 프로바이더: {provider}").into());
+    }
+
+    // API 키 입력
+    let key_prompt = match provider {
+        "anthropic" => "Anthropic API 키를 입력하세요: ",
+        "openai" => "OpenAI API 키를 입력하세요: ",
+        _ => unreachable!(),
+    };
+    eprint!("{key_prompt}");
+    let mut api_key = String::new();
+    std::io::stdin().read_line(&mut api_key)?;
+    let api_key = api_key.trim().to_string();
+
+    if api_key.is_empty() {
+        return Err("API 키가 비어있습니다.".into());
+    }
+
+    // 출력 경로 자동 감지
+    let output_path = default_output_path();
+    match detect_obsidian_vault() {
+        Some(vault) => {
+            eprintln!("Obsidian vault 감지됨: {}", vault.display());
+            eprintln!("출력 경로: {}/Daily/", output_path.display());
+        }
+        None => {
+            eprintln!("Obsidian vault를 찾지 못했습니다.");
+            eprintln!("기본 출력 경로: {}/Daily/", output_path.display());
+        }
+    }
+
+    let config = Config {
+        llm: LlmConfig {
+            provider: provider.to_string(),
+            api_key,
+        },
+        output: OutputConfig {
+            path: output_path.to_string_lossy().to_string(),
+        },
+    };
+
+    save_config(&config, &config_file)?;
+    eprintln!("설정 저장 완료: {}", config_file.display());
+    Ok(())
+}
+
+/// rwd config <key> <value> — 개별 설정 값을 변경합니다.
+/// 기존 설정 파일을 읽고, 해당 키만 수정한 뒤 다시 저장합니다.
+pub fn run_config(key: &str, value: &str) -> Result<(), ConfigError> {
+    let config_file = config_path()?;
+
+    if !config_file.exists() {
+        return Err("설정 파일이 없습니다. 먼저 `rwd init`을 실행해 주세요.".into());
+    }
+
+    let mut config = load_config(&config_file)?;
+
+    match key {
+        "output-path" => {
+            config.output.path = value.to_string();
+            eprintln!("출력 경로 변경: {value}");
+        }
+        "provider" => {
+            if !["anthropic", "openai"].contains(&value) {
+                return Err(format!(
+                    "지원하지 않는 프로바이더: '{value}'. 사용 가능: anthropic, openai"
+                ).into());
+            }
+            config.llm.provider = value.to_string();
+            eprintln!("LLM 프로바이더 변경: {value}");
+        }
+        "api-key" => {
+            config.llm.api_key = value.to_string();
+            eprintln!("API 키 변경 완료");
+        }
+        _ => {
+            return Err(format!(
+                "알 수 없는 설정 키: '{key}'. 사용 가능: output-path, provider, api-key"
+            ).into());
+        }
+    }
+
+    save_config(&config, &config_file)?;
+    Ok(())
+}
+
+/// 주어진 디렉토리 하위에서 .obsidian 폴더가 있는 디렉토리를 찾습니다.
+/// .obsidian 폴더는 Obsidian이 vault로 인식하는 마커입니다.
+/// read_dir()로 1단계 깊이만 탐색합니다 — 깊은 중첩은 불필요합니다.
+pub fn detect_vault_in_dir(search_dir: &std::path::Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(search_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.join(".obsidian").is_dir() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Obsidian vault를 자동 감지합니다.
+/// ~/Documents/Obsidian/ 하위에서 .obsidian 마커를 탐색합니다.
+/// 찾지 못하면 None 반환 — 호출부에서 기본 경로를 사용합니다.
+pub fn detect_obsidian_vault() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let obsidian_dir = home.join("Documents").join("Obsidian");
+    detect_vault_in_dir(&obsidian_dir)
+}
+
+/// 기본 출력 경로(vault root)를 결정합니다.
+/// 1. Obsidian vault 자동 감지 → {vault} (vault root 반환)
+/// 2. 감지 실패 → ~/.rwd/output (기본 경로)
+///
+/// 주의: Daily/ 하위 디렉토리는 save_to_vault()가 자동으로 붙입니다.
+pub fn default_output_path() -> PathBuf {
+    if let Some(vault) = detect_obsidian_vault() {
+        return vault;
+    }
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(".rwd").join("output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_path_rwd_디렉토리_포함() {
+        let path = config_path().expect("경로 생성 성공");
+        assert!(path.ends_with("rwd/config.toml"));
+    }
+
+    #[test]
+    fn test_save_and_load_config_왕복_확인() {
+        let temp_dir = std::env::temp_dir().join("rwd_test_config");
+        let _ = std::fs::remove_dir_all(&temp_dir); // 이전 테스트 잔여물 정리
+        std::fs::create_dir_all(&temp_dir).expect("디렉토리 생성");
+        let path = temp_dir.join("config.toml");
+
+        let config = Config {
+            llm: LlmConfig {
+                provider: "anthropic".to_string(),
+                api_key: "sk-test-key".to_string(),
+            },
+            output: OutputConfig {
+                path: "/tmp/vault".to_string(),
+            },
+        };
+
+        save_config(&config, &path).expect("저장 성공");
+        let loaded = load_config(&path).expect("로드 성공");
+
+        assert_eq!(loaded.llm.provider, "anthropic");
+        assert_eq!(loaded.llm.api_key, "sk-test-key");
+        assert_eq!(loaded.output.path, "/tmp/vault");
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_detect_obsidian_vault_obsidian폴더_있으면_경로반환() {
+        let temp_dir = std::env::temp_dir().join("rwd_test_vault_detect");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        let vault_dir = temp_dir.join("TestVault");
+        let obsidian_marker = vault_dir.join(".obsidian");
+        std::fs::create_dir_all(&obsidian_marker).expect("디렉토리 생성");
+
+        let result = detect_vault_in_dir(&temp_dir);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), vault_dir);
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_detect_obsidian_vault_없으면_None() {
+        let temp_dir = std::env::temp_dir().join("rwd_test_no_vault");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).expect("디렉토리 생성");
+
+        let result = detect_vault_in_dir(&temp_dir);
+        assert!(result.is_none());
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // Rust는 파일 하나가 모듈 하나에 대응됩니다 — cli.rs 파일이 cli 모듈이 됩니다 (Rust Book Ch.7 참조).
 mod analyzer;
 mod cli;
+mod config;
 mod output;
 mod parser;
 
@@ -27,6 +28,18 @@ async fn main() {
             // .await는 "이 비동기 작업이 끝날 때까지 기다려라"는 의미입니다.
             if let Err(e) = run_today().await {
                 eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Commands::Init => {
+            if let Err(e) = config::run_init() {
+                eprintln!("초기 설정 실패: {e}");
+                std::process::exit(1);
+            }
+        }
+        Commands::Config { key, value } => {
+            if let Err(e) = config::run_config(&key, &value) {
+                eprintln!("설정 변경 실패: {e}");
                 std::process::exit(1);
             }
         }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -12,34 +12,24 @@ use std::path::{Path, PathBuf};
 
 use chrono::NaiveDate;
 
-/// Obsidian vault 경로를 환경 변수에서 읽습니다.
-///
-/// analyzer/mod.rs의 load_api_key()와 같은 패턴입니다:
-/// dotenvy로 .env 파일을 로드한 뒤, std::env::var()로 환경 변수를 읽습니다.
+/// Obsidian vault 경로를 설정 파일(~/.config/rwd/config.toml)에서 읽습니다.
 ///
 /// PathBuf는 소유권을 가진 경로 타입입니다 — String이 &str의 소유 버전인 것처럼,
 /// PathBuf는 &Path의 소유 버전입니다 (Rust Book Ch.12 참조).
-/// PathBuf::from()은 문자열을 OS 경로로 변환합니다.
 pub fn load_vault_path() -> Result<PathBuf, OutputError> {
-    // .env 파일이 있으면 로드, 없으면 무시 — 환경 변수가 직접 설정된 경우를 지원합니다.
-    dotenvy::dotenv().ok();
-
-    let path_str = std::env::var("RWD_VAULT_PATH").map_err(|_| {
-        "RWD_VAULT_PATH가 설정되지 않았습니다. \
-         .env 파일에 추가하거나 환경 변수를 설정해 주세요. \
-         예: echo 'RWD_VAULT_PATH=/path/to/obsidian/vault' >> .env"
+    let config = crate::config::load_config_if_exists().ok_or_else(|| {
+        let hint = if std::path::Path::new(".env").exists() {
+            " (기존 .env 사용자: `rwd init`으로 설정을 마이그레이션하세요)"
+        } else {
+            ""
+        };
+        format!("설정 파일이 없습니다. `rwd init`을 먼저 실행해 주세요.{hint}")
     })?;
 
-    let path = PathBuf::from(&path_str);
-
-    // .exists()와 .is_dir()는 파일 시스템을 조회하여 경로 상태를 확인합니다.
+    let path = PathBuf::from(&config.output.path);
     if !path.exists() {
-        return Err(format!("Vault 경로가 존재하지 않습니다: {}", path.display()).into());
+        std::fs::create_dir_all(&path)?;
     }
-    if !path.is_dir() {
-        return Err(format!("Vault 경로가 디렉토리가 아닙니다: {}", path.display()).into());
-    }
-
     Ok(path)
 }
 


### PR DESCRIPTION
## Summary
- M5 설정 시스템 구현 완료 (rwd init/config)
- .env/dotenvy 제거, config.toml 단일 소스 전환
- Obsidian vault 자동 감지

🤖 Generated with [Claude Code](https://claude.com/claude-code)