### PR TITLE
feat: rwd update 셀프 업데이트 + 버전 체크 알림

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,4 +28,6 @@ pub enum Commands {
         /// 설정할 값
         value: String,
     },
+    /// 최신 버전으로 업데이트합니다
+    Update,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod config;
 mod output;
 mod parser;
+mod update;
 
 // use 키워드로 다른 모듈의 항목을 현재 스코프로 가져옵니다.
 use clap::Parser;
@@ -43,6 +44,12 @@ async fn main() {
                 std::process::exit(1);
             }
         }
+        Commands::Update => {
+            if let Err(e) = update::run_update().await {
+                eprintln!("업데이트 실패: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 }
 
@@ -52,6 +59,9 @@ async fn main() {
 /// 비동기 함수는 호출 시 즉시 실행되지 않고, .await를 만나야 실행됩니다.
 /// 여기서는 analyzer::analyze_entries() 호출이 네트워크 I/O를 수행하므로 async가 필요합니다.
 async fn run_today() -> Result<(), parser::ParseError> {
+    // 업데이트 알림 체크 — 실패해도 무시 (네트워크 없는 환경 대응)
+    update::notify_if_update_available().await;
+
     // 설정 파일이 없으면 init을 먼저 실행하도록 안내하고 중단합니다.
     if config::load_config_if_exists().is_none() {
         eprintln!("설정 파일이 없습니다. 먼저 `rwd init`을 실행해 주세요.");

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,164 @@
+// update 모듈은 GitHub Releases를 통한 버전 체크 및 셀프 업데이트를 담당합니다.
+// reqwest로 GitHub API를 호출하고, 바이너리를 다운받아 현재 실행 파일을 교체합니다.
+
+use std::path::PathBuf;
+
+const REPO: &str = "gigagookbob/rwd";
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// GitHub API에서 최신 릴리즈 태그를 가져옵니다.
+/// env!("CARGO_PKG_VERSION")은 컴파일 시점에 Cargo.toml의 version 값을 문자열로 삽입합니다.
+pub async fn check_latest_version() -> Result<String, Box<dyn std::error::Error>> {
+    let url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let client = reqwest::Client::new();
+    let resp: serde_json::Value = client
+        .get(&url)
+        .header("User-Agent", "rwd")
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let tag = resp
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .ok_or("릴리즈 태그를 찾을 수 없습니다")?;
+
+    // "v0.1.0" → "0.1.0"
+    Ok(tag.trim_start_matches('v').to_string())
+}
+
+/// 현재 버전보다 새 버전이 있으면 안내 메시지를 출력합니다.
+/// rwd today 시작 시 호출됩니다.
+pub async fn notify_if_update_available() {
+    match check_latest_version().await {
+        Ok(latest) if latest != CURRENT_VERSION => {
+            eprintln!(
+                "새 버전이 있습니다: v{latest} (현재: v{CURRENT_VERSION})"
+            );
+            eprintln!("업데이트: rwd update\n");
+        }
+        _ => {}
+    }
+}
+
+/// 셀프 업데이트를 수행합니다.
+/// 1. GitHub API에서 최신 릴리즈의 바이너리 URL을 가져옴
+/// 2. 바이너리를 다운로드
+/// 3. 현재 실행 파일을 교체
+pub async fn run_update() -> Result<(), Box<dyn std::error::Error>> {
+    let latest = check_latest_version().await?;
+
+    if latest == CURRENT_VERSION {
+        eprintln!("이미 최신 버전입니다: v{CURRENT_VERSION}");
+        return Ok(());
+    }
+
+    eprintln!("v{CURRENT_VERSION} → v{latest} 업데이트 중...");
+
+    // 플랫폼별 에셋 이름 결정
+    let asset_name = detect_asset_name()?;
+    let download_url = format!(
+        "https://github.com/{REPO}/releases/download/v{latest}/{asset_name}"
+    );
+
+    // 바이너리 다운로드
+    eprintln!("다운로드: {download_url}");
+    let client = reqwest::Client::new();
+    let bytes = client
+        .get(&download_url)
+        .header("User-Agent", "rwd")
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    // 임시 파일에 저장 후 압축 해제
+    let tmp_dir = std::env::temp_dir().join("rwd_update");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+    std::fs::create_dir_all(&tmp_dir)?;
+
+    let archive_path = tmp_dir.join(&asset_name);
+    std::fs::write(&archive_path, &bytes)?;
+
+    // tar.gz 압축 해제 — Unix에서 tar 명령어를 사용합니다.
+    let status = std::process::Command::new("tar")
+        .args(["-xzf", &archive_path.to_string_lossy(), "-C", &tmp_dir.to_string_lossy()])
+        .status()?;
+
+    if !status.success() {
+        return Err("압축 해제 실패".into());
+    }
+
+    // 추출된 바이너리 찾기
+    let extracted = find_binary_in_dir(&tmp_dir)?;
+
+    // 현재 실행 파일 교체
+    let current_exe = std::env::current_exe()?;
+    replace_binary(&extracted, &current_exe)?;
+
+    // 정리
+    std::fs::remove_dir_all(&tmp_dir).ok();
+
+    eprintln!("rwd v{latest} 업데이트 완료!");
+    Ok(())
+}
+
+/// 플랫폼에 맞는 에셋 파일명을 반환합니다.
+fn detect_asset_name() -> Result<String, Box<dyn std::error::Error>> {
+    let arch = std::env::consts::ARCH;
+    let os = std::env::consts::OS;
+
+    let name = match (os, arch) {
+        ("macos", "aarch64") => "rwd-aarch64-apple-darwin.tar.gz",
+        ("macos", "x86_64") => "rwd-x86_64-apple-darwin.tar.gz",
+        ("linux", "x86_64") => "rwd-x86_64-unknown-linux-gnu.tar.gz",
+        _ => return Err(format!("지원하지 않는 플랫폼: {os}-{arch}").into()),
+    };
+    Ok(name.to_string())
+}
+
+/// 디렉토리에서 rwd 바이너리를 찾습니다.
+fn find_binary_in_dir(dir: &std::path::Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        // tar.gz이 아닌 rwd로 시작하는 파일이 바이너리
+        if name.starts_with("rwd") && !name.ends_with(".tar.gz") && path.is_file() {
+            return Ok(path);
+        }
+    }
+    Err("업데이트 바이너리를 찾을 수 없습니다".into())
+}
+
+/// 바이너리를 교체합니다.
+/// Unix에서는 실행 중인 파일도 교체 가능합니다 (inode 기반 파일 시스템).
+fn replace_binary(
+    new_binary: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // 실행 권한 설정
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(new_binary, std::fs::Permissions::from_mode(0o755))?;
+    }
+
+    // /usr/local/bin 등에 있으면 권한이 필요할 수 있음
+    match std::fs::copy(new_binary, target) {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            // sudo로 재시도
+            eprintln!("관리자 권한이 필요합니다.");
+            let status = std::process::Command::new("sudo")
+                .args(["cp", &new_binary.to_string_lossy(), &target.to_string_lossy()])
+                .status()?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err("바이너리 교체 실패".into())
+            }
+        }
+        Err(e) => Err(e.into()),
+    }
+}


### PR DESCRIPTION
## Summary
- `rwd update` — GitHub Release에서 최신 바이너리 다운로드 및 셀프 교체
- `rwd today` — 실행 시 최신 버전 확인, 새 버전 있으면 안내 메시지
- 플랫폼 자동 감지 (macOS ARM/Intel, Linux x86_64)

## Test plan
- [x] `cargo build` / `cargo clippy` / `cargo test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)