### PR TITLE
ci: add automatic PR labeling and release note categorization

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels: ["enhancement"]
+    - title: "🐛 Bug Fixes"
+      labels: ["bug"]
+    - title: "⚡ Performance"
+      labels: ["performance"]
+    - title: "📖 Documentation"
+      labels: ["documentation"]
+    - title: "🔧 Maintenance"
+      labels: ["chore", "dependencies"]
+    - title: "Other Changes"
+      labels: ["*"]

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,42 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label from PR title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prefixMap = {
+              'feat':  'enhancement',
+              'fix':   'bug',
+              'perf':  'performance',
+              'docs':  'documentation',
+              'chore': 'chore',
+              'refactor': 'chore',
+              'ci':    'chore',
+              'test':  'chore',
+            };
+
+            const match = title.match(/^(\w+)(\(.+\))?[!]?:/);
+            if (!match) return;
+
+            const prefix = match[1];
+            const label = prefixMap[prefix];
+            if (!label) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });


### PR DESCRIPTION
## Summary
- PR 제목의 conventional commit prefix (`fix:`, `feat:`, `docs:` 등)에서 라벨 자동 부여
- 릴리즈 노트를 라벨 기반으로 카테고리 자동 분류 (Features, Bug Fixes, Performance, Documentation, Maintenance)

## How it works
1. PR 생성/수정 시 `pr-labeler.yml` 워크플로우가 제목 prefix를 파싱하여 라벨 부여
2. 릴리즈 시 `softprops/action-gh-release`의 `generate_release_notes: true`가 `.github/release.yml`의 카테고리 설정을 참조하여 자동 정리

## Test plan
- [ ] 이 PR 자체에 `chore` 라벨이 자동으로 붙는지 확인