### PR TITLE
fix: add linux target to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 


### PR DESCRIPTION
## Summary
- add `x86_64-unknown-linux-gnu` to the release build matrix
- run the Linux build on `ubuntu-latest` in the release workflow
- keep existing packaging and release upload steps unchanged

## Verification
- cargo build
- cargo clippy
- cargo test