### PR TITLE
chore: split release trigger and publish workflows

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,0 +1,58 @@
+name: Release On Main
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - src/**
+      - prompts/**
+      - Cargo.toml
+      - Cargo.lock
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-trigger-main
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.tag_check.outputs.should_release }}
+      tag_name: ${{ steps.version.outputs.tag_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag from Cargo.toml version
+        id: version
+        run: |
+          VERSION=$(awk -F '"' '/^version = / { print $2; exit }' Cargo.toml)
+          if [ -z "$VERSION" ]; then
+            echo "Failed to read version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "tag_name=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether tag already exists
+        id: tag_check
+        run: |
+          TAG="${{ steps.version.outputs.tag_name }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists. Skipping release."
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} does not exist. Proceeding release."
+          fi
+
+  release:
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.preflight.outputs.tag_name }}
+      target_sha: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,43 @@
-name: Release
+name: Release Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      target_sha:
+        required: true
+        type: string
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ inputs.tag_name }}
+  cancel-in-progress: false
+
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+
+    steps:
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}.git" "refs/tags/${{ inputs.tag_name }}" >/dev/null 2>&1; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ inputs.tag_name }} already exists. Skipping release."
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ inputs.tag_name }} does not exist. Proceeding release."
+          fi
+
   build:
+    needs: guard
+    if: needs.guard.outputs.should_release == 'true'
     strategy:
       matrix:
         include:
@@ -53,12 +81,11 @@ jobs:
           path: rwd-${{ matrix.target }}.*
 
   release:
-    needs: build
+    needs: [guard, build]
+    if: needs.guard.outputs.should_release == 'true'
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -67,6 +94,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag_name }}
+          target_commitish: ${{ inputs.target_sha }}
           generate_release_notes: true
           files: |
             rwd-*.tar.gz


### PR DESCRIPTION
## Summary
- split release automation into two workflows
- add `release-on-main.yml` to detect code changes on `main` and decide whether to release
- convert `release.yml` into a reusable publish workflow (`workflow_call`)
- gate release by SemVer tag existence to avoid duplicate releases

## Behavior
- Trigger only on `main` pushes that touch `src/**`, `prompts/**`, `Cargo.toml`, or `Cargo.lock`
- Read version from `Cargo.toml` and compute `v<version>` tag
- If tag already exists, skip publishing
- If tag does not exist, build and publish release artifacts

## Verification
- cargo build
- cargo clippy
- cargo test