### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump package version from `0.12.0` to `0.12.1`
- update lockfile root package version accordingly

## Why
- trigger SemVer-based release flow for Linux/macOS/Windows artifacts after promotion to `main`

## Verification
- cargo build
- cargo clippy
- cargo test