### PR TITLE
chore: promote dev to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ rwd answers **"What did I decide today, and why?"** — it extracts decisions, c
 ### One-line install (macOS Apple Silicon / Linux x86_64)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash
 ```
 
 ### One-line install (Windows)

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
+
+if [ -z "${BASH_VERSION:-}" ]; then
+    echo "오류: 이 설치 스크립트는 bash가 필요합니다." >&2
+    echo "다음처럼 실행하세요: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 # rwd 설치 스크립트
-# 사용법: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | sh
+# 사용법: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash
 
 REPO="gigagookbob/rwd"
 INSTALL_DIR="/usr/local/bin"


### PR DESCRIPTION
## Summary
- promote `dev` into `main`
- include install script shell compatibility fix and README command update

## Included commits
- cb52dfc Merge pull request #74 from gigagookbob/fix/require-bash-for-install-script
- 6dc02b0 fix: require bash for install script and update docs

## Note
- This change does not touch release trigger paths (`src/**`, `prompts/**`, `Cargo.toml`, `Cargo.lock`), so release should not run.