### PR TITLE
fix: improve installer guidance and remove clippy warnings

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -49,8 +49,10 @@ if (-not (Test-Path $DefaultOutput)) {
 
 # Add to user PATH if not already present
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$PathUpdated = $false
 if ($UserPath -notlike "*$InstallDir*") {
     [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+    $PathUpdated = $true
     Write-Host "Added $InstallDir to user PATH (restart terminal to apply)."
 }
 
@@ -58,13 +60,26 @@ if ($UserPath -notlike "*$InstallDir*") {
 Remove-Item $TmpDir -Recurse -Force
 
 Write-Host ""
-Write-Host "rwd $Version installed!"
+Write-Host "rwd $Version installed successfully!"
 Write-Host "Location: $InstallDir\$BinaryName"
 Write-Host "Default output: $DefaultOutput"
 Write-Host ""
-Write-Host "NOTE: Restart your terminal for 'rwd' to be available." -ForegroundColor Yellow
-Write-Host "  Or run directly now: $InstallDir\$BinaryName --version" -ForegroundColor Yellow
+Write-Host "Next steps:"
+Write-Host "  1) Verify install: rwd --version"
+Write-Host "  2) Initial setup:  rwd init"
+Write-Host "  3) Run analysis:   rwd today"
 Write-Host ""
-Write-Host "Get started:"
-Write-Host "  rwd init     # Initial setup (API key, output path)"
-Write-Host "  rwd today    # Analyze today's sessions"
+Write-Host "Tip: You can update settings later with 'rwd config'."
+
+if ($PathUpdated) {
+    Write-Host ""
+    Write-Host "NOTE: Restart your terminal for 'rwd' to be available." -ForegroundColor Yellow
+    Write-Host "  Or run directly now: $InstallDir\$BinaryName --version" -ForegroundColor Yellow
+} else {
+    Write-Host ""
+    Write-Host "If 'rwd' is not found in this shell, run directly now:" -ForegroundColor Yellow
+    Write-Host "  $InstallDir\$BinaryName --version" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Done."

--- a/install.sh
+++ b/install.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env bash
 
 if [ -z "${BASH_VERSION:-}" ]; then
-    echo "오류: 이 설치 스크립트는 bash가 필요합니다." >&2
-    echo "다음처럼 실행하세요: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash" >&2
+    echo "Error: This installer requires bash." >&2
+    echo "Run: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash" >&2
     exit 1
 fi
 
 set -euo pipefail
 
-# rwd 설치 스크립트
-# 사용법: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash
+# rwd install script
+# Usage: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash
 
 REPO="gigagookbob/rwd"
 INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="rwd"
 
-# 최신 릴리즈 태그 가져오기
+# Fetch latest release tag
 VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 if [ -z "$VERSION" ]; then
-    echo "오류: 릴리즈 버전을 가져올 수 없습니다."
+    echo "Error: Failed to fetch latest release version."
     exit 1
 fi
 
-echo "rwd ${VERSION} 설치 중..."
+echo "Installing rwd ${VERSION}..."
 
-# 아키텍처 감지
+# Detect architecture
 ARCH=$(uname -m)
 OS=$(uname -s)
 
@@ -40,51 +40,64 @@ case "${OS}-${ARCH}" in
         ASSET="rwd-x86_64-unknown-linux-gnu.tar.gz"
         ;;
     *)
-        echo "오류: 지원하지 않는 플랫폼입니다: ${OS}-${ARCH}"
-        echo "소스에서 직접 빌드하세요: cargo install --git https://github.com/${REPO}.git"
+        echo "Error: Unsupported platform: ${OS}-${ARCH}"
+        echo "Build from source: cargo install --git https://github.com/${REPO}.git"
         exit 1
         ;;
 esac
 
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
 
-# 임시 디렉토리에 다운로드
+# Download to temp directory
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-echo "다운로드: ${DOWNLOAD_URL}"
+echo "Downloading: ${DOWNLOAD_URL}"
 curl -fsSL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ASSET}"
 
-# 압축 해제
+# Extract archive
 tar -xzf "${TMP_DIR}/${ASSET}" -C "$TMP_DIR"
 
-# 바이너리 이름 찾기 (tar에서 추출된 파일)
+# Locate extracted binary
 EXTRACTED=$(find "$TMP_DIR" -type f -name "rwd*" ! -name "*.tar.gz" | head -1)
 
 if [ -z "$EXTRACTED" ]; then
-    echo "오류: 바이너리를 찾을 수 없습니다."
+    echo "Error: Failed to locate extracted binary."
     exit 1
 fi
 
-# 설치
+# Install binary
 chmod +x "$EXTRACTED"
 if [ -w "$INSTALL_DIR" ]; then
     mv "$EXTRACTED" "${INSTALL_DIR}/${BINARY_NAME}"
 else
-    echo "관리자 권한이 필요합니다."
+    echo "Administrator privileges required to write to ${INSTALL_DIR}."
     sudo mv "$EXTRACTED" "${INSTALL_DIR}/${BINARY_NAME}"
 fi
 
-# 기본 출력 디렉토리 생성 (~/.rwd/output/)
-# Obsidian vault를 설정하지 않아도 바로 사용할 수 있도록 미리 만들어 둡니다.
+# Create default output directory (~/.rwd/output/)
+# This allows immediate use before Obsidian path is configured.
 DEFAULT_OUTPUT="${HOME}/.rwd/output"
 mkdir -p "$DEFAULT_OUTPUT"
 
 echo ""
-echo "rwd ${VERSION} 설치 완료!"
-echo "위치: ${INSTALL_DIR}/${BINARY_NAME}"
-echo "기본 출력 경로: ${DEFAULT_OUTPUT}"
+echo "rwd ${VERSION} installed successfully!"
+echo "Binary location: ${INSTALL_DIR}/${BINARY_NAME}"
+echo "Default output directory: ${DEFAULT_OUTPUT}"
 echo ""
-echo "시작하기:"
-echo "  rwd init     # 초기 설정 (API 키, 출력 경로)"
-echo "  rwd today    # 오늘의 세션 분석"
+echo "Next steps:"
+echo "  1) Verify install: rwd --version"
+echo "  2) Initial setup:  rwd init"
+echo "  3) Run analysis:   rwd today"
+echo ""
+echo "Tip: After \`rwd init\`, config is saved at ~/.config/rwd/config.toml."
+
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+        echo ""
+        echo "Note: ${INSTALL_DIR} is not in PATH for this shell."
+        echo "Add this line to ~/.bashrc, then restart your terminal:"
+        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+        ;;
+esac

--- a/src/analyzer/insight.rs
+++ b/src/analyzer/insight.rs
@@ -112,10 +112,10 @@ pub fn parse_response(raw_text: &str) -> Result<AnalysisResult, super::AnalyzerE
 /// Tries `{"sessions"` first (most specific), then falls back to any `{`.
 fn extract_json_object(text: &str) -> Result<AnalysisResult, serde_json::Error> {
     // Try the most specific marker first.
-    if let Some(start) = text.find("{\"sessions\"") {
-        if let Ok(result) = serde_json::from_str::<AnalysisResult>(&text[start..]) {
-            return Ok(result);
-        }
+    if let Some(start) = text.find("{\"sessions\"")
+        && let Ok(result) = serde_json::from_str::<AnalysisResult>(&text[start..])
+    {
+        return Ok(result);
     }
     // Fall back to first '{'.
     if let Some(start) = text.find('{') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,10 +281,10 @@ fn resolve_lang(
         };
     }
     // 2. Config value
-    if let Some(cfg) = loaded_config.as_ref() {
-        if let Some(lang) = &cfg.lang {
-            return Ok(lang.clone());
-        }
+    if let Some(cfg) = loaded_config.as_ref()
+        && let Some(lang) = &cfg.lang
+    {
+        return Ok(lang.clone());
     }
     // 3. Migration prompt — ask user and save to config
     eprint!("{}", crate::messages::lang::NOT_CONFIGURED);


### PR DESCRIPTION
## Summary
- normalize install.sh user-facing messages to English and improve post-install guidance
- align install.ps1 post-install guidance with the same flow
- resolve two clippy::collapsible_if warnings using let-chains in parsing/lang resolution paths

## Verification
- cargo build
- cargo clippy
- cargo test