### PR TITLE
feat: improve analysis pipeline and cache controls

### DIFF
--- a/docs/superpowers/plans/2026-04-11-multi-root-agent-session-discovery-next-session-prompt.md
+++ b/docs/superpowers/plans/2026-04-11-multi-root-agent-session-discovery-next-session-prompt.md
@@ -1,0 +1,52 @@
+# Next Session Prompt — Multi-Root Agent Session Discovery
+
+다음 세션에서 아래 프롬프트를 그대로 사용한다.
+
+```text
+/home/jinwoo/workspace/hobby/rwd 레포에서 아래 설계를 구현해줘.
+
+먼저 이 문서를 읽어:
+- docs/superpowers/specs/2026-04-11-multi-root-agent-session-discovery-design.md
+
+이번 작업 목표:
+- Claude Code와 Codex 세션 로그를 "하나의 루트만 선택"하지 말고, 존재하는 모든 유효 루트에서 수집하도록 구현
+- /home 계열 경로와 /mnt/c/... 계열 경로가 동시에 존재하면 둘 다 읽기
+- 같은 세션/같은 엔트리가 중복 수집되면 dedupe
+- Config override도 지원하기
+
+구현 원칙:
+- Rust 2024 stable 기준
+- 작은 단계로 나눠서 구현
+- 새로운 Rust 개념을 쓰면 왜 필요한지 설명
+- unwrap() 대신 Result와 ? 사용
+- 가능하면 공용 helper로 Claude/Codex의 중복 경로 탐색 로직을 정리
+- Context7 MCP가 사용 가능하면 관련 crate API를 먼저 확인하고, 불가능하면 그 사실을 짧게 기록
+
+구체 요구사항:
+- src/config.rs에 optional [input] 섹션 추가
+  - input.codex_roots: Option<Vec<String>>
+  - input.claude_roots: Option<Vec<String>>
+- parser layer에 multi-root discovery API 추가
+  - Claude: discover_claude_log_roots()
+  - Codex: discover_codex_session_roots()
+- WSL 환경에서는 /home 루트와 /mnt/c/Users/* 후보를 모두 수집
+- Codex는 session_id 기준으로 세션 merge
+- Claude는 entry fingerprint 기준으로 dedupe
+- main.rs의 collect_claude_entries_with_stats, collect_claude_entries, collect_codex_sessions를 multi-root 기반으로 바꾸기
+- verbose 모드에서 실제 사용한 루트 목록을 출력하도록 개선하면 더 좋음
+
+검증은 반드시 이 순서로:
+- cargo build
+- cargo clippy --all-targets --all-features -- -D warnings
+- cargo test
+
+주의:
+- 구현은 이번 턴에서만 하고, 설계 재논의로 시간을 오래 쓰지 말 것
+- /home와 /mnt 둘 다 존재할 때 한쪽만 우선 선택하는 기존 동작을 유지하면 안 됨
+- app vs CLI로 분기하지 말고, 실제 로그 루트 목록을 기준으로 처리할 것
+
+작업이 끝나면 다음을 정리해줘:
+- 어떤 루트 해석 우선순위로 구현했는지
+- Codex/Claude dedupe key가 각각 무엇인지
+- 남은 리스크가 있으면 무엇인지
+```

--- a/docs/superpowers/specs/2026-04-11-multi-root-agent-session-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-11-multi-root-agent-session-discovery-design.md
@@ -1,0 +1,239 @@
+# Multi-Root Agent Session Discovery
+
+## Problem
+
+현재 `rwd`는 Claude Code와 Codex 로그를 각각 "하나의 루트 경로"에서만 찾는다.
+
+- Claude Code: `~/.claude/projects`가 존재하면 그 경로만 사용하고, 없을 때만 WSL의 `/mnt/c/Users/.../.claude/projects` fallback을 본다.
+- Codex: `~/.codex/sessions`가 존재하면 그 경로만 사용하고, 없을 때만 WSL의 `/mnt/c/Users/.../.codex/sessions` fallback을 본다.
+
+이 구조는 하이브리드 환경에서 실제 작업 일부를 누락시킨다.
+
+### 실제로 문제가 되는 시나리오
+
+1. WSL CLI로 작업한 Codex 세션은 `/home/jinwoo/.codex/sessions`에 쌓임
+2. Codex Desktop App 세션은 `/mnt/c/Users/qew85/.codex/sessions`에 쌓임
+3. 두 경로가 모두 존재하면 현재 구현은 `/home/...`만 읽고 `/mnt/...`는 무시함
+4. 결과적으로 `rwd today`가 오늘의 실제 작업 일부를 놓침
+
+Claude Code도 같은 문제가 생길 수 있다.
+
+1. WSL 안에서 Claude CLI를 사용하면 `/home/jinwoo/.claude/projects`
+2. Windows 쪽 Claude 환경을 WSL에서 읽으면 `/mnt/c/Users/.../.claude/projects`
+3. 두 경로가 동시에 존재할 수 있음
+
+## Goal
+
+Claude Code와 Codex 모두 "단일 루트 선택"이 아니라 "존재하는 모든 유효 루트를 수집"하도록 바꾼다.
+
+핵심 목표는 다음 두 가지다.
+
+- 하이브리드 환경에서도 로그 누락 없이 분석하기
+- 같은 세션/같은 엔트리가 여러 루트에 중복으로 존재해도 중복 분석하지 않기
+
+## Non-Goals
+
+- Codex Desktop App의 `CODEX_HOME` 자체를 옮기거나 자동 마이그레이션하지 않는다
+- 사용자 파일을 `/mnt`와 `/home` 사이에서 자동 복사/동기화하지 않는다
+- 이번 변경에서 경로 정책을 강제하지 않는다
+
+`rwd`의 역할은 "현재 존재하는 로그를 최대한 정확하게 발견하고 합쳐서 분석"하는 데 한정한다.
+
+## Proposed Solution
+
+### 1. Single-root API를 Multi-root API로 교체
+
+현재의:
+
+- `parser::discover_log_dir() -> Result<PathBuf, _>`
+- `parser::codex::discover_codex_sessions_dir() -> Result<PathBuf, _>`
+
+를 다음 개념으로 바꾼다.
+
+- `discover_claude_log_roots(...) -> Vec<PathBuf>`
+- `discover_codex_session_roots(...) -> Vec<PathBuf>`
+
+반환값은 "우선순위가 반영된, dedupe된 루트 목록"이다.
+
+### 2. Root resolution order
+
+각 provider의 루트는 아래 순서로 수집한다.
+
+1. 명시적 config override
+2. provider-specific env-derived root
+3. native home root
+4. WSL에서 보이는 Windows home roots
+
+Codex 예시:
+
+1. `config.input.codex_roots`
+2. `CODEX_HOME/sessions` if `CODEX_HOME` is set
+3. `~/.codex/sessions`
+4. `/mnt/c/Users/*/.codex/sessions` candidates in WSL
+
+Claude 예시:
+
+1. `config.input.claude_roots`
+2. `~/.claude/projects`
+3. `/mnt/c/Users/*/.claude/projects` candidates in WSL
+
+### 3. Config shape
+
+새 설정 섹션을 추가한다.
+
+```toml
+[input]
+codex_roots = [
+  "/home/jinwoo/.codex/sessions",
+  "/mnt/c/Users/qew85/.codex/sessions",
+]
+claude_roots = [
+  "/home/jinwoo/.claude/projects",
+  "/mnt/c/Users/qew85/.claude/projects",
+]
+```
+
+설정이 없으면 자동 탐색을 사용한다.
+설정이 있으면 그 경로를 최우선으로 사용하되, 존재하는 경로만 채택한다.
+
+### 4. Merge strategy
+
+루트를 여러 개 읽더라도 "같은 데이터를 두 번 분석"하면 안 된다.
+
+#### Codex merge key
+
+- 1차 key: `session_id`
+- fallback key: `(root_path, rollout_filename)`
+
+같은 `session_id`를 가진 세션이 여러 루트에서 발견되면 엔트리를 합친다.
+
+엔트리 dedupe는 fingerprint 기반으로 한다.
+
+- `SessionMeta`: `(timestamp, session_id, cwd, model_provider)`
+- `UserMessage`: `(timestamp, text)`
+- `AssistantMessage`: `(timestamp, text)`
+- `FunctionCall`: `(timestamp, name)`
+- `Other`: skip or keep only once with coarse fingerprint
+
+합쳐진 엔트리는 timestamp 기준으로 정렬한 뒤 기존 분석 파이프라인으로 넘긴다.
+
+#### Claude merge key
+
+Claude는 entry-level dedupe가 더 안전하다.
+
+- `User`: `(session_id, uuid)`
+- `Assistant`: `(session_id, uuid)`
+- `Progress`: `(session_id, timestamp)`
+- `System`: `(session_id_or_empty, timestamp)`
+- `FileHistorySnapshot`: `(message_id_or_empty)`
+
+여러 project root에서 읽은 오늘 엔트리를 하나의 벡터로 합친 뒤 fingerprint로 dedupe한다.
+이후 기존 `summarize_entries()`와 분석 파이프라인을 그대로 사용한다.
+
+### 5. Shared discovery helper
+
+Claude와 Codex의 WSL/Windows 경로 탐색 로직은 거의 동일하다.
+중복 코드를 줄이기 위해 공용 helper를 도입한다.
+
+예상 위치:
+
+- 새 모듈 `src/parser/roots.rs`
+
+역할:
+
+- `is_wsl_environment()`
+- `wsl_windows_home_candidates()`
+- `dedupe_existing_paths(paths: Vec<PathBuf>) -> Vec<PathBuf>`
+
+이 helper를 Claude/Codex parser 양쪽에서 재사용한다.
+
+## Architecture Impact
+
+### Affected files
+
+- `src/config.rs`
+- `src/parser/mod.rs`
+- `src/parser/claude.rs`
+- `src/parser/codex.rs`
+- `src/main.rs`
+- 가능하면 새 파일 `src/parser/roots.rs`
+
+### Core flow changes
+
+Before:
+
+```text
+discover one root -> read files from one root -> analyze
+```
+
+After:
+
+```text
+discover multiple roots -> read files from all roots -> dedupe/merge -> analyze
+```
+
+## Design Decisions
+
+### Why not branch by "app vs CLI"?
+
+그 기준은 겉으로는 직관적이지만 실제 저장 위치를 보장하지 않는다.
+
+- Codex Desktop App도 WSL 백엔드를 사용할 수 있다
+- CLI도 `CODEX_HOME`에 따라 `/mnt`를 쓸 수 있다
+
+따라서 제품 코드는 "사용자 종류"가 아니라 "실제 로그 루트"를 기준으로 동작해야 한다.
+
+### Why config + env + fallback order?
+
+- Config가 가장 명시적이라 재현 가능성이 높다
+- `CODEX_HOME`은 Codex에서 사실상 공식 홈 지시자 역할을 한다
+- 홈 경로 fallback은 설정이 없는 사용자를 위한 안전망이다
+
+### Why merge instead of choosing one root?
+
+이 문제의 본질은 "어느 경로가 진실 원본인가"보다 "오늘 실제 작업이 여러 루트에 분산될 수 있다"는 점이다.
+
+루트 하나만 선택하면 반드시 누락 케이스가 생긴다.
+
+## Test Plan
+
+### Root discovery
+
+- unit test: config root와 auto-discovered root가 함께 존재할 때 우선순위가 유지되는지
+- unit test: `/home`와 `/mnt`가 모두 존재하면 둘 다 반환되는지
+- unit test: 중복 경로가 dedupe되는지
+
+### Codex merge
+
+- unit test: `/home`와 `/mnt`에서 서로 다른 session_id 두 개가 들어오면 둘 다 수집되는지
+- unit test: 같은 session_id가 두 루트에 중복 존재하면 하나의 세션으로 merge되는지
+- unit test: merged entries가 timestamp 순서로 정렬되는지
+
+### Claude merge
+
+- unit test: 두 root에서 같은 `(session_id, uuid)` 엔트리가 들어오면 한 번만 남는지
+- unit test: 서로 다른 root의 서로 다른 session_id 엔트리는 모두 보존되는지
+
+### Integration
+
+- `rwd today`가 `/home` only, `/mnt` only, `/home + /mnt` 세 경우 모두 정상 동작하는지
+- `cargo build`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test`
+
+## Migration Notes
+
+- 기존 config 파일에는 `[input]` 섹션이 없으므로 `Option<InputConfig>`로 추가한다
+- 섹션이 없으면 기존 사용자도 자동 탐색으로 계속 동작해야 한다
+- cache key 구조 변경은 이번 설계 범위에 포함하지 않는다
+
+## Recommended First Implementation Slice
+
+한 번에 전부 바꾸기보다 아래 순서가 안전하다.
+
+1. `Config`에 optional `[input]` 섹션 추가
+2. 공용 root discovery helper 추가
+3. Codex multi-root 수집 + dedupe/merge 구현
+4. Claude multi-root 수집 + dedupe 구현
+5. verbose 출력에 실제 사용한 루트 목록 추가
+

--- a/src/analyzer/anthropic.rs
+++ b/src/analyzer/anthropic.rs
@@ -1,7 +1,7 @@
 // Anthropic Claude Messages API client.
 
-use serde::{Deserialize, Serialize};
 use super::planner::RateLimits;
+use serde::{Deserialize, Serialize};
 
 const API_URL: &str = "https://api.anthropic.com/v1/messages";
 const API_VERSION: &str = "2023-06-01";
@@ -85,10 +85,13 @@ pub async fn call_anthropic_api(
 
     let api_response: ApiResponse = response.json().await?;
 
-    let usage = api_response.usage.map(|u| super::ApiUsage {
-        input_tokens: u.input_tokens,
-        output_tokens: u.output_tokens,
-    }).unwrap_or_default();
+    let usage = api_response
+        .usage
+        .map(|u| super::ApiUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+        })
+        .unwrap_or_default();
 
     let text = api_response
         .content
@@ -133,10 +136,13 @@ pub async fn call_anthropic_api_with_max_tokens(
     }
     let api_response: ApiResponse = response.json().await?;
 
-    let usage = api_response.usage.map(|u| super::ApiUsage {
-        input_tokens: u.input_tokens,
-        output_tokens: u.output_tokens,
-    }).unwrap_or_default();
+    let usage = api_response
+        .usage
+        .map(|u| super::ApiUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+        })
+        .unwrap_or_default();
 
     let text = api_response
         .content

--- a/src/analyzer/insight.rs
+++ b/src/analyzer/insight.rs
@@ -128,10 +128,7 @@ fn extract_json_object(text: &str) -> Result<AnalysisResult, serde_json::Error> 
 /// Merges multiple AnalysisResults into one by concatenating their session vecs.
 /// Used to combine per-session fallback results into a single output.
 pub fn merge_results(results: Vec<AnalysisResult>) -> AnalysisResult {
-    let sessions = results
-        .into_iter()
-        .flat_map(|r| r.sessions)
-        .collect();
+    let sessions = results.into_iter().flat_map(|r| r.sessions).collect();
     AnalysisResult { sessions }
 }
 

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -55,7 +55,11 @@ async fn countdown_sleep(total_secs: u64) {
     let mut i = 0;
     for remaining in (1..=total_secs).rev() {
         for _ in 0..12 {
-            eprint!("\r{} {}", frames[i % frames.len()], crate::messages::status::countdown_waiting(remaining));
+            eprint!(
+                "\r{} {}",
+                frames[i % frames.len()],
+                crate::messages::status::countdown_waiting(remaining)
+            );
             let _ = std::io::stderr().flush();
             i += 1;
             tokio::time::sleep(std::time::Duration::from_millis(83)).await;
@@ -151,16 +155,39 @@ pub async fn analyze_entries(
         } else {
             (prompt_text, RedactResult::empty())
         };
-        let (raw_response, usage) = provider.call_api(&api_key, &final_prompt, plan.recommended_max_tokens as u32, lang).await?;
+        let (raw_response, usage) = provider
+            .call_api(
+                &api_key,
+                &final_prompt,
+                plan.recommended_max_tokens as u32,
+                lang,
+            )
+            .await?;
         let elapsed = started.elapsed();
         stop_spinner(sp);
         if verbose {
-            eprintln!("{}", crate::messages::verbose::api_done_single(elapsed.as_secs_f64(), usage.input_tokens, usage.output_tokens));
+            eprintln!(
+                "{}",
+                crate::messages::verbose::api_done_single(
+                    elapsed.as_secs_f64(),
+                    usage.input_tokens,
+                    usage.output_tokens
+                )
+            );
         }
         let result = insight::parse_response(&raw_response)?;
         Ok((result, redact_result))
     } else {
-        execute_plan(&plan, entries, &provider, &api_key, redactor_enabled, verbose, lang).await
+        execute_plan(
+            &plan,
+            entries,
+            &provider,
+            &api_key,
+            redactor_enabled,
+            verbose,
+            lang,
+        )
+        .await
     }
 }
 
@@ -176,16 +203,26 @@ fn entry_session_id(entry: &LogEntry) -> Option<&str> {
 }
 
 /// Generates a development progress summary from concatenated session work_summaries.
-pub async fn analyze_summary(session_summaries: &str, lang: &crate::config::Lang) -> Result<String, AnalyzerError> {
+pub async fn analyze_summary(
+    session_summaries: &str,
+    lang: &crate::config::Lang,
+) -> Result<String, AnalyzerError> {
     let (provider, api_key) = provider::load_provider()?;
-    let (raw_response, _usage) = provider.call_summary_api(&api_key, session_summaries, lang).await?;
+    let (raw_response, _usage) = provider
+        .call_summary_api(&api_key, session_summaries, lang)
+        .await?;
     Ok(raw_response)
 }
 
 /// Generates a Slack-ready message from concatenated session work_summaries.
-pub async fn analyze_slack(session_summaries: &str, lang: &crate::config::Lang) -> Result<String, AnalyzerError> {
+pub async fn analyze_slack(
+    session_summaries: &str,
+    lang: &crate::config::Lang,
+) -> Result<String, AnalyzerError> {
     let (provider, api_key) = provider::load_provider()?;
-    let (raw_response, _usage) = provider.call_slack_api(&api_key, session_summaries, lang).await?;
+    let (raw_response, _usage) = provider
+        .call_slack_api(&api_key, session_summaries, lang)
+        .await?;
     Ok(raw_response)
 }
 
@@ -203,7 +240,9 @@ pub async fn analyze_codex_entries(
     } else {
         (prompt_text, RedactResult::empty())
     };
-    let (raw_response, _usage) = provider.call_api(&api_key, &final_prompt, 1_950, lang).await?;
+    let (raw_response, _usage) = provider
+        .call_api(&api_key, &final_prompt, 1_950, lang)
+        .await?;
     let result = insight::parse_response(&raw_response)?;
     Ok((result, redact_result))
 }
@@ -233,19 +272,19 @@ async fn execute_plan(
         let use_spinner = step.strategy == StepStrategy::Direct;
         let step_start = std::time::Instant::now();
         let sp = if use_spinner {
-            Some(start_spinner(
-                crate::messages::status::step_analyzing(i + 1, total_steps, &step.session_id)
-            ))
+            Some(start_spinner(crate::messages::status::step_analyzing(
+                i + 1,
+                total_steps,
+                &step.session_id,
+            )))
         } else {
             None
         };
 
         let result = match &step.strategy {
             StepStrategy::Direct => {
-                execute_direct_step(
-                    &session_entries, provider, api_key, redactor_enabled, lang,
-                )
-                .await
+                execute_direct_step(&session_entries, provider, api_key, redactor_enabled, lang)
+                    .await
             }
             StepStrategy::Summarize { .. } => {
                 execute_summarize_step(
@@ -263,13 +302,22 @@ async fn execute_plan(
 
         match result {
             Ok((analysis, redact, usage)) => {
-                if let Some(h) = sp { stop_spinner(h); }
+                if let Some(h) = sp {
+                    stop_spinner(h);
+                }
                 let elapsed = step_start.elapsed();
                 if verbose {
-                    eprintln!("{}", crate::messages::verbose::step_done_detail(
-                        i + 1, total_steps, &step.session_id,
-                        elapsed.as_secs_f64(), usage.input_tokens, usage.output_tokens,
-                    ));
+                    eprintln!(
+                        "{}",
+                        crate::messages::verbose::step_done_detail(
+                            i + 1,
+                            total_steps,
+                            &step.session_id,
+                            elapsed.as_secs_f64(),
+                            usage.input_tokens,
+                            usage.output_tokens,
+                        )
+                    );
                 } else {
                     eprintln!("{}", crate::messages::status::step_done(i + 1, total_steps));
                 }
@@ -277,16 +325,20 @@ async fn execute_plan(
                 total_redact.merge(redact);
             }
             Err(e) => {
-                if let Some(h) = sp { stop_spinner(h); }
+                if let Some(h) = sp {
+                    stop_spinner(h);
+                }
                 let err_msg = e.to_string();
                 if err_msg.contains("429") {
                     // 429 rate limit: wait 60s then retry
                     countdown_sleep(60).await;
 
                     let retry_sp = if use_spinner {
-                        Some(start_spinner(
-                            crate::messages::status::step_retrying(i + 1, total_steps, &step.session_id)
-                        ))
+                        Some(start_spinner(crate::messages::status::step_retrying(
+                            i + 1,
+                            total_steps,
+                            &step.session_id,
+                        )))
                     } else {
                         None
                     };
@@ -318,25 +370,39 @@ async fn execute_plan(
 
                     match retry {
                         Ok((analysis, redact, _usage)) => {
-                            if let Some(h) = retry_sp { stop_spinner(h); }
-                            eprintln!("{}", crate::messages::status::step_retry_success(i + 1, total_steps));
+                            if let Some(h) = retry_sp {
+                                stop_spinner(h);
+                            }
+                            eprintln!(
+                                "{}",
+                                crate::messages::status::step_retry_success(i + 1, total_steps)
+                            );
                             results.push(analysis);
                             total_redact.merge(redact);
                         }
                         Err(retry_err) => {
-                            if let Some(h) = retry_sp { stop_spinner(h); }
+                            if let Some(h) = retry_sp {
+                                stop_spinner(h);
+                            }
                             eprintln!(
                                 "{}",
-                                crate::messages::status::step_skip_retry(i + 1, total_steps, &step.session_id, &retry_err)
+                                crate::messages::status::step_skip_retry(
+                                    i + 1,
+                                    total_steps,
+                                    &step.session_id,
+                                    &retry_err
+                                )
                             );
                         }
                     }
                 } else if err_msg.contains(crate::messages::error::JSON_PARSE_FAILED_MARKER) {
                     // JSON parse failure: retry with a stronger JSON-only instruction
                     let retry_sp = if use_spinner {
-                        Some(start_spinner(
-                            crate::messages::status::step_reanalyzing(i + 1, total_steps, &step.session_id)
-                        ))
+                        Some(start_spinner(crate::messages::status::step_reanalyzing(
+                            i + 1,
+                            total_steps,
+                            &step.session_id,
+                        )))
                     } else {
                         None
                     };
@@ -344,14 +410,23 @@ async fn execute_plan(
                     let retry = match &step.strategy {
                         StepStrategy::Direct => {
                             execute_direct_step_with_json_hint(
-                                &session_entries, provider, api_key, redactor_enabled, lang,
+                                &session_entries,
+                                provider,
+                                api_key,
+                                redactor_enabled,
+                                lang,
                             )
                             .await
                         }
                         StepStrategy::Summarize { .. } => {
                             execute_summarize_step_with_json_hint(
-                                &session_entries, &step.session_id,
-                                provider, api_key, &plan.rate_limits, redactor_enabled, lang,
+                                &session_entries,
+                                &step.session_id,
+                                provider,
+                                api_key,
+                                &plan.rate_limits,
+                                redactor_enabled,
+                                lang,
                             )
                             .await
                         }
@@ -359,23 +434,43 @@ async fn execute_plan(
 
                     match retry {
                         Ok((analysis, redact, _usage)) => {
-                            if let Some(h) = retry_sp { stop_spinner(h); }
-                            eprintln!("{}", crate::messages::status::step_reanalysis_success(i + 1, total_steps));
+                            if let Some(h) = retry_sp {
+                                stop_spinner(h);
+                            }
+                            eprintln!(
+                                "{}",
+                                crate::messages::status::step_reanalysis_success(
+                                    i + 1,
+                                    total_steps
+                                )
+                            );
                             results.push(analysis);
                             total_redact.merge(redact);
                         }
                         Err(retry_err) => {
-                            if let Some(h) = retry_sp { stop_spinner(h); }
+                            if let Some(h) = retry_sp {
+                                stop_spinner(h);
+                            }
                             eprintln!(
                                 "{}",
-                                crate::messages::status::step_skip_reanalysis(i + 1, total_steps, &step.session_id, &retry_err)
+                                crate::messages::status::step_skip_reanalysis(
+                                    i + 1,
+                                    total_steps,
+                                    &step.session_id,
+                                    &retry_err
+                                )
                             );
                         }
                     }
                 } else {
                     eprintln!(
                         "{}",
-                        crate::messages::status::step_skip(i + 1, total_steps, &step.session_id, &err_msg)
+                        crate::messages::status::step_skip(
+                            i + 1,
+                            total_steps,
+                            &step.session_id,
+                            &err_msg
+                        )
                     );
                 }
             }
@@ -383,8 +478,7 @@ async fn execute_plan(
 
         // Rate pacing: wait between steps (skip after the last one).
         if i + 1 < total_steps {
-            let wait =
-                summarizer::calculate_wait(step.estimated_tokens, &plan.rate_limits);
+            let wait = summarizer::calculate_wait(step.estimated_tokens, &plan.rate_limits);
             if wait > 0.0 {
                 countdown_sleep(wait.ceil() as u64).await;
             }
@@ -420,7 +514,9 @@ async fn execute_direct_step(
     } else {
         (prompt_text, RedactResult::empty())
     };
-    let (raw_response, usage) = provider.call_api(api_key, &final_prompt, 4_096, lang).await?;
+    let (raw_response, usage) = provider
+        .call_api(api_key, &final_prompt, 4_096, lang)
+        .await?;
     let result = insight::parse_response(&raw_response)?;
     Ok((result, redact_result, usage))
 }
@@ -440,7 +536,9 @@ async fn execute_direct_step_with_json_hint(
     } else {
         (hinted, RedactResult::empty())
     };
-    let (raw_response, usage) = provider.call_api(api_key, &final_prompt, 4_096, lang).await?;
+    let (raw_response, usage) = provider
+        .call_api(api_key, &final_prompt, 4_096, lang)
+        .await?;
     let result = insight::parse_response(&raw_response)?;
     Ok((result, redact_result, usage))
 }
@@ -456,8 +554,7 @@ async fn execute_summarize_step(
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
     let messages = prompt::extract_messages(entries);
-    let chunks =
-        summarizer::split_into_chunks(&messages, limits.input_tokens_per_minute);
+    let chunks = summarizer::split_into_chunks(&messages, limits.input_tokens_per_minute);
     let summary_text =
         summarizer::summarize_chunks(&chunks, provider, api_key, limits, lang).await?;
 
@@ -467,7 +564,9 @@ async fn execute_summarize_step(
     } else {
         (prompt_with_session, RedactResult::empty())
     };
-    let (raw_response, usage) = provider.call_api(api_key, &final_prompt, 4_096, lang).await?;
+    let (raw_response, usage) = provider
+        .call_api(api_key, &final_prompt, 4_096, lang)
+        .await?;
     let result = insight::parse_response(&raw_response)?;
     Ok((result, redact_result, usage))
 }
@@ -483,8 +582,7 @@ async fn execute_summarize_step_with_json_hint(
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
     let messages = prompt::extract_messages(entries);
-    let chunks =
-        summarizer::split_into_chunks(&messages, limits.input_tokens_per_minute);
+    let chunks = summarizer::split_into_chunks(&messages, limits.input_tokens_per_minute);
     let summary_text =
         summarizer::summarize_chunks(&chunks, provider, api_key, limits, lang).await?;
 
@@ -494,7 +592,9 @@ async fn execute_summarize_step_with_json_hint(
     } else {
         (prompt_with_session, RedactResult::empty())
     };
-    let (raw_response, usage) = provider.call_api(api_key, &final_prompt, 4_096, lang).await?;
+    let (raw_response, usage) = provider
+        .call_api(api_key, &final_prompt, 4_096, lang)
+        .await?;
     let result = insight::parse_response(&raw_response)?;
     Ok((result, redact_result, usage))
 }

--- a/src/analyzer/openai.rs
+++ b/src/analyzer/openai.rs
@@ -1,7 +1,7 @@
 // OpenAI Chat Completions API client.
 
-use serde::{Deserialize, Serialize};
 use super::planner::RateLimits;
+use serde::{Deserialize, Serialize};
 
 const API_URL: &str = "https://api.openai.com/v1/chat/completions";
 const MODEL: &str = "gpt-4o";
@@ -101,10 +101,13 @@ pub async fn call_openai_api(
 
     let chat_response: ChatResponse = response.json().await?;
 
-    let usage = chat_response.usage.map(|u| super::ApiUsage {
-        input_tokens: u.prompt_tokens,
-        output_tokens: u.completion_tokens,
-    }).unwrap_or_default();
+    let usage = chat_response
+        .usage
+        .map(|u| super::ApiUsage {
+            input_tokens: u.prompt_tokens,
+            output_tokens: u.completion_tokens,
+        })
+        .unwrap_or_default();
 
     let text = chat_response
         .choices
@@ -154,10 +157,13 @@ pub async fn call_openai_api_with_max_tokens(
     }
     let chat_response: ChatResponse = response.json().await?;
 
-    let usage = chat_response.usage.map(|u| super::ApiUsage {
-        input_tokens: u.prompt_tokens,
-        output_tokens: u.completion_tokens,
-    }).unwrap_or_default();
+    let usage = chat_response
+        .usage
+        .map(|u| super::ApiUsage {
+            input_tokens: u.prompt_tokens,
+            output_tokens: u.completion_tokens,
+        })
+        .unwrap_or_default();
 
     let text = chat_response
         .choices
@@ -260,6 +266,6 @@ mod tests {
     fn test_empty_choices() {
         let json = r#"{"choices": []}"#;
         let response: ChatResponse = serde_json::from_str(json).unwrap();
-        assert!(response.choices.first().is_none());
+        assert!(response.choices.is_empty());
     }
 }

--- a/src/analyzer/planner.rs
+++ b/src/analyzer/planner.rs
@@ -87,9 +87,7 @@ pub fn build_execution_plan(
     let recommended_max_tokens = (estimated_output as u64).min(model_max_output);
 
     // Single-shot condition: both input AND output fit within limits.
-    if total + SUMMARY_BUDGET_TOKENS <= itpm
-        && (estimated_output as u64) <= model_max_output
-    {
+    if total + SUMMARY_BUDGET_TOKENS <= itpm && (estimated_output as u64) <= model_max_output {
         return ExecutionPlan {
             rate_limits: limits.clone(),
             steps: Vec::new(),
@@ -107,7 +105,9 @@ pub fn build_execution_plan(
                 StepStrategy::Direct
             } else {
                 let chunks = ((est.estimated_tokens as f64) / (itpm as f64)).ceil() as usize;
-                StepStrategy::Summarize { chunks: chunks.max(2) }
+                StepStrategy::Summarize {
+                    chunks: chunks.max(2),
+                }
             };
             ExecutionStep {
                 session_id: est.session_id.clone(),
@@ -146,8 +146,14 @@ mod tests {
             requests_per_minute: 100,
         };
         let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 10_000 },
-            SessionEstimate { session_id: "s2".into(), estimated_tokens: 20_000 },
+            SessionEstimate {
+                session_id: "s1".into(),
+                estimated_tokens: 10_000,
+            },
+            SessionEstimate {
+                session_id: "s2".into(),
+                estimated_tokens: 20_000,
+            },
         ];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(plan.is_single_shot);
@@ -163,8 +169,14 @@ mod tests {
             requests_per_minute: 50,
         };
         let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 10_000 },
-            SessionEstimate { session_id: "s2".into(), estimated_tokens: 20_000 },
+            SessionEstimate {
+                session_id: "s1".into(),
+                estimated_tokens: 10_000,
+            },
+            SessionEstimate {
+                session_id: "s2".into(),
+                estimated_tokens: 20_000,
+            },
         ];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(!plan.is_single_shot);
@@ -180,21 +192,26 @@ mod tests {
             output_tokens_per_minute: 8_000,
             requests_per_minute: 50,
         };
-        let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 50_000 },
-        ];
+        let estimates = vec![SessionEstimate {
+            session_id: "s1".into(),
+            estimated_tokens: 50_000,
+        }];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(!plan.is_single_shot);
         assert_eq!(plan.steps.len(), 1);
-        assert_eq!(plan.steps[0].strategy, StepStrategy::Summarize { chunks: 2 });
+        assert_eq!(
+            plan.steps[0].strategy,
+            StepStrategy::Summarize { chunks: 2 }
+        );
     }
 
     #[test]
     fn test_build_plan_default_generous_is_single_shot() {
         let limits = RateLimits::default_generous();
-        let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 50_000 },
-        ];
+        let estimates = vec![SessionEstimate {
+            session_id: "s1".into(),
+            estimated_tokens: 50_000,
+        }];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(plan.is_single_shot);
     }
@@ -206,9 +223,10 @@ mod tests {
             output_tokens_per_minute: 8_000,
             requests_per_minute: 50,
         };
-        let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 31_000 },
-        ];
+        let estimates = vec![SessionEstimate {
+            session_id: "s1".into(),
+            estimated_tokens: 31_000,
+        }];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(!plan.is_single_shot);
     }
@@ -220,9 +238,10 @@ mod tests {
             output_tokens_per_minute: 8_000,
             requests_per_minute: 50,
         };
-        let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 30_000 },
-        ];
+        let estimates = vec![SessionEstimate {
+            session_id: "s1".into(),
+            estimated_tokens: 30_000,
+        }];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(plan.is_single_shot);
     }
@@ -245,8 +264,14 @@ mod tests {
     fn test_single_shot_allowed_when_output_fits() {
         let limits = RateLimits::default_generous();
         let estimates = vec![
-            SessionEstimate { session_id: "s1".into(), estimated_tokens: 50_000 },
-            SessionEstimate { session_id: "s2".into(), estimated_tokens: 30_000 },
+            SessionEstimate {
+                session_id: "s1".into(),
+                estimated_tokens: 50_000,
+            },
+            SessionEstimate {
+                session_id: "s2".into(),
+                estimated_tokens: 30_000,
+            },
         ];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
         assert!(plan.is_single_shot);

--- a/src/analyzer/prompt.rs
+++ b/src/analyzer/prompt.rs
@@ -35,10 +35,7 @@ fn extract_conversation_text(entries: &[LogEntry]) -> String {
                     if !sessions.contains_key(session_id) {
                         session_order.push(session_id);
                     }
-                    sessions
-                        .entry(session_id)
-                        .or_default()
-                        .push(("USER", text));
+                    sessions.entry(session_id).or_default().push(("USER", text));
                 }
             }
             LogEntry::Assistant(e) => {

--- a/src/analyzer/summarizer.rs
+++ b/src/analyzer/summarizer.rs
@@ -21,10 +21,7 @@ pub fn get_chunk_summarize_prompt(lang: &Lang) -> &'static str {
 /// Splits messages into chunks that fit within the ITPM limit.
 /// Splits only at message boundaries (never mid-message).
 /// A single message exceeding the limit becomes its own chunk.
-pub fn split_into_chunks(
-    messages: &[(String, String)],
-    itpm: u64,
-) -> Vec<Vec<(String, String)>> {
+pub fn split_into_chunks(messages: &[(String, String)], itpm: u64) -> Vec<Vec<(String, String)>> {
     if messages.is_empty() {
         return Vec::new();
     }
@@ -84,12 +81,7 @@ pub async fn summarize_chunks(
         let sp = super::start_spinner(crate::messages::status::chunk_summarizing(i + 1, total));
 
         let (summary, _usage) = provider
-            .call_api_with_max_tokens(
-                api_key,
-                get_chunk_summarize_prompt(lang),
-                &chunk_text,
-                2000,
-            )
+            .call_api_with_max_tokens(api_key, get_chunk_summarize_prompt(lang), &chunk_text, 2000)
             .await?;
         super::stop_spinner(sp);
         eprintln!("{}", crate::messages::status::chunk_done(i + 1, total));
@@ -127,9 +119,7 @@ mod tests {
 
     #[test]
     fn test_split_into_chunks_single_message_exceeds_limit() {
-        let messages = vec![
-            ("USER".to_string(), "a".repeat(100)),
-        ];
+        let messages = vec![("USER".to_string(), "a".repeat(100))];
         let chunks = split_into_chunks(&messages, 25);
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].len(), 1);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -23,6 +23,12 @@ pub struct TodayCache {
     pub date: String,
     pub claude_entry_count: usize,
     pub codex_session_count: usize,
+    /// Total parsed Codex entries for the target date.
+    ///
+    /// Added after `codex_session_count` to avoid false cache hits when
+    /// conversations continue inside existing sessions.
+    #[serde(default)]
+    pub codex_entry_count: usize,
     /// Per-source analysis results.
     pub sources: Vec<(String, AnalysisResult)>,
 }
@@ -79,7 +85,10 @@ pub fn save_update_check(cache: &UpdateCheckCache) -> Result<(), CacheError> {
 }
 
 /// Saves update check cache to a specific path (for testability).
-fn save_update_check_to(cache: &UpdateCheckCache, path: &std::path::Path) -> Result<(), CacheError> {
+fn save_update_check_to(
+    cache: &UpdateCheckCache,
+    path: &std::path::Path,
+) -> Result<(), CacheError> {
     let json = serde_json::to_string_pretty(cache)?;
     std::fs::write(path, json)?;
     Ok(())
@@ -126,5 +135,17 @@ mod tests {
         let _ = std::fs::remove_file(&path);
         let loaded = load_update_check_from(&path);
         assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn test_today_cache_deserialize_legacy_json_defaults_codex_entry_count() {
+        let json = r#"{
+  "date":"2026-04-11",
+  "claude_entry_count":10,
+  "codex_session_count":2,
+  "sources":[]
+}"#;
+        let loaded: TodayCache = serde_json::from_str(json).expect("deserialize legacy cache");
+        assert_eq!(loaded.codex_entry_count, 0);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,12 +9,15 @@ use clap::{Parser, Subcommand};
     after_help = "\
 Examples:
   rwd today                         Analyze and print results
+  rwd today --no-cache              Force fresh analysis (ignore cache)
   rwd today -v                      Show detailed execution plan
   rwd today -b                      Run in background, notify when done
   rwd today --date 2026-04-09       Analyze a specific date
   rwd summary                       Summarize today's work and save to Obsidian
+  rwd summary --no-cache            Refresh analysis before summary
   rwd summary --date 2026-04-09     Summarize a specific date
   rwd slack                         Generate Slack message and copy to clipboard
+  rwd slack --no-cache              Refresh analysis before Slack message
   rwd slack --date 2026-04-09       Generate Slack message for a specific date
   rwd init                          Set up provider credentials and output path
   rwd config                        Interactive settings menu
@@ -38,6 +41,7 @@ pub enum Commands {
     #[command(after_help = "\
 Examples:
   rwd today                    Analyze and print results
+  rwd today --no-cache         Force fresh analysis (ignore cache)
   rwd today -v                 Show detailed execution plan
   rwd today -b                 Run in background, notify when done
   rwd today --date 2026-04-09  Analyze a specific date")]
@@ -54,6 +58,9 @@ Examples:
         /// Run in background with OS notification on completion
         #[arg(long, short)]
         background: bool,
+        /// Ignore cache and force fresh analysis
+        #[arg(long)]
+        no_cache: bool,
         /// Internal: run as background worker (hidden from help)
         #[arg(long, hide = true)]
         worker: bool,
@@ -66,6 +73,9 @@ Examples:
         /// Target date (YYYY-MM-DD), defaults to today
         #[arg(long)]
         date: Option<String>,
+        /// Refresh today's analysis before generating summary
+        #[arg(long)]
+        no_cache: bool,
     },
     /// Generate a Slack-ready message and copy to clipboard
     Slack {
@@ -75,6 +85,9 @@ Examples:
         /// Target date (YYYY-MM-DD), defaults to today
         #[arg(long)]
         date: Option<String>,
+        /// Refresh today's analysis before generating Slack message
+        #[arg(long)]
+        no_cache: bool,
     },
     /// Run initial setup (provider credentials, output path)
     Init,

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -10,10 +10,7 @@ use crate::analyzer::insight::{AnalysisResult, SessionInsight, TilItem};
 /// Each source is separated by a ## heading.
 ///
 /// sources: slice of (source name, analysis result) tuples.
-pub fn render_combined_markdown(
-    sources: &[(&str, &AnalysisResult)],
-    date: NaiveDate,
-) -> String {
+pub fn render_combined_markdown(sources: &[(&str, &AnalysisResult)], date: NaiveDate) -> String {
     let mut md = String::new();
     md.push_str(&format!("# {date} Dev Session Review\n\n"));
 
@@ -58,10 +55,17 @@ pub fn render_markdown(analysis: &AnalysisResult, date: NaiveDate) -> String {
 /// TIL items are collected separately and not rendered here.
 fn render_session(md: &mut String, session: &SessionInsight) {
     md.push_str(&format!("## Session: {}\n\n", session.session_id));
-    md.push_str(&format!("{}\n{}\n\n", crate::messages::markdown::WORK_SUMMARY_HEADER, session.work_summary));
+    md.push_str(&format!(
+        "{}\n{}\n\n",
+        crate::messages::markdown::WORK_SUMMARY_HEADER,
+        session.work_summary
+    ));
 
     if !session.decisions.is_empty() {
-        md.push_str(&format!("{}\n", crate::messages::markdown::DECISIONS_HEADER));
+        md.push_str(&format!(
+            "{}\n",
+            crate::messages::markdown::DECISIONS_HEADER
+        ));
         for d in &session.decisions {
             md.push_str(&format!("- **{}**: {}\n", d.what, d.why));
         }
@@ -69,7 +73,10 @@ fn render_session(md: &mut String, session: &SessionInsight) {
     }
 
     if !session.curiosities.is_empty() {
-        md.push_str(&format!("{}\n", crate::messages::markdown::CURIOSITIES_HEADER));
+        md.push_str(&format!(
+            "{}\n",
+            crate::messages::markdown::CURIOSITIES_HEADER
+        ));
         for c in &session.curiosities {
             md.push_str(&format!("- {c}\n"));
         }
@@ -77,9 +84,18 @@ fn render_session(md: &mut String, session: &SessionInsight) {
     }
 
     if !session.corrections.is_empty() {
-        md.push_str(&format!("{}\n", crate::messages::markdown::CORRECTIONS_HEADER));
+        md.push_str(&format!(
+            "{}\n",
+            crate::messages::markdown::CORRECTIONS_HEADER
+        ));
         for c in &session.corrections {
-            md.push_str(&format!("- {}: {}\n  {}: {}\n", crate::messages::markdown::CORRECTION_MODEL, c.model_said, crate::messages::markdown::CORRECTION_FIX, c.user_corrected));
+            md.push_str(&format!(
+                "- {}: {}\n  {}: {}\n",
+                crate::messages::markdown::CORRECTION_MODEL,
+                c.model_said,
+                crate::messages::markdown::CORRECTION_FIX,
+                c.user_corrected
+            ));
         }
         md.push('\n');
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -13,8 +13,7 @@ use chrono::NaiveDate;
 
 /// Loads the Obsidian vault path from config (~/.config/rwd/config.toml).
 pub fn load_vault_path() -> Result<PathBuf, OutputError> {
-    let config = crate::config::load_config_if_exists()
-        .ok_or(crate::messages::error::NO_CONFIG)?;
+    let config = crate::config::load_config_if_exists().ok_or(crate::messages::error::NO_CONFIG)?;
 
     let path = PathBuf::from(&config.output.path);
     if !path.exists() {
@@ -40,7 +39,6 @@ pub fn save_to_vault(
 
     Ok(file_path)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/redactor/mod.rs
+++ b/src/redactor/mod.rs
@@ -58,7 +58,13 @@ pub fn redact_text(text: &str) -> (String, RedactResult) {
         }
     }
 
-    (result_text, RedactResult { total_count, by_type })
+    (
+        result_text,
+        RedactResult {
+            total_count,
+            by_type,
+        },
+    )
 }
 
 #[cfg(test)]
@@ -191,10 +197,7 @@ mod tests {
     fn test_format_summary_alphabetical() {
         let result = RedactResult {
             total_count: 4,
-            by_type: BTreeMap::from([
-                ("PRIVATE_IP".to_string(), 1),
-                ("API_KEY".to_string(), 3),
-            ]),
+            by_type: BTreeMap::from([("PRIVATE_IP".to_string(), 1), ("API_KEY".to_string(), 3)]),
         };
         assert_eq!(result.format_summary(), "API_KEY: 3, PRIVATE_IP: 1");
     }

--- a/src/redactor/patterns.rs
+++ b/src/redactor/patterns.rs
@@ -29,10 +29,12 @@ pub fn builtin_rules() -> Vec<RedactorRule> {
         LazyLock::new(|| Regex::new(r"\bgh[ps]_[a-zA-Z0-9]{36,}\b").expect("GITHUB_TOKEN regex"));
     static SLACK_TOKEN: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\bxox[bpsa]-[a-zA-Z0-9\-]+\b").expect("SLACK_TOKEN regex"));
-    static BEARER_TOKEN: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"Bearer\s+[a-zA-Z0-9\-._~+/]+=*").expect("BEARER_TOKEN regex"));
+    static BEARER_TOKEN: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"Bearer\s+[a-zA-Z0-9\-._~+/]+=*").expect("BEARER_TOKEN regex")
+    });
     static ENV_SECRET: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r#"(?i)(password|secret|api_key)\s*=\s*["'][^"']+["']"#).expect("ENV_SECRET regex")
+        Regex::new(r#"(?i)(password|secret|api_key)\s*=\s*["'][^"']+["']"#)
+            .expect("ENV_SECRET regex")
     });
     static PRIVATE_IP: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"\b(10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+)\b")
@@ -43,13 +45,45 @@ pub fn builtin_rules() -> Vec<RedactorRule> {
     });
 
     vec![
-        RedactorRule { name: "API_KEY", kind: PatternKind::FixedPrefix, pattern: &API_KEY },
-        RedactorRule { name: "AWS_KEY", kind: PatternKind::FixedPrefix, pattern: &AWS_KEY },
-        RedactorRule { name: "GITHUB_TOKEN", kind: PatternKind::FixedPrefix, pattern: &GITHUB_TOKEN },
-        RedactorRule { name: "SLACK_TOKEN", kind: PatternKind::FixedPrefix, pattern: &SLACK_TOKEN },
-        RedactorRule { name: "BEARER_TOKEN", kind: PatternKind::Regex, pattern: &BEARER_TOKEN },
-        RedactorRule { name: "ENV_SECRET", kind: PatternKind::Regex, pattern: &ENV_SECRET },
-        RedactorRule { name: "PRIVATE_IP", kind: PatternKind::Regex, pattern: &PRIVATE_IP },
-        RedactorRule { name: "PRIVATE_KEY", kind: PatternKind::Regex, pattern: &PRIVATE_KEY },
+        RedactorRule {
+            name: "API_KEY",
+            kind: PatternKind::FixedPrefix,
+            pattern: &API_KEY,
+        },
+        RedactorRule {
+            name: "AWS_KEY",
+            kind: PatternKind::FixedPrefix,
+            pattern: &AWS_KEY,
+        },
+        RedactorRule {
+            name: "GITHUB_TOKEN",
+            kind: PatternKind::FixedPrefix,
+            pattern: &GITHUB_TOKEN,
+        },
+        RedactorRule {
+            name: "SLACK_TOKEN",
+            kind: PatternKind::FixedPrefix,
+            pattern: &SLACK_TOKEN,
+        },
+        RedactorRule {
+            name: "BEARER_TOKEN",
+            kind: PatternKind::Regex,
+            pattern: &BEARER_TOKEN,
+        },
+        RedactorRule {
+            name: "ENV_SECRET",
+            kind: PatternKind::Regex,
+            pattern: &ENV_SECRET,
+        },
+        RedactorRule {
+            name: "PRIVATE_IP",
+            kind: PatternKind::Regex,
+            pattern: &PRIVATE_IP,
+        },
+        RedactorRule {
+            name: "PRIVATE_KEY",
+            kind: PatternKind::Regex,
+            pattern: &PRIVATE_KEY,
+        },
     ]
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -44,9 +44,7 @@ pub async fn notify_if_update_available() {
     if let Some(cached) = crate::cache::load_update_check() {
         let now = chrono::Utc::now();
         let interval = chrono::Duration::hours(24);
-        if is_newer(&cached.latest_version, CURRENT_VERSION)
-            && now - cached.checked_at < interval
-        {
+        if is_newer(&cached.latest_version, CURRENT_VERSION) && now - cached.checked_at < interval {
             print_update_notice(&cached.latest_version);
             return;
         }
@@ -84,17 +82,22 @@ pub async fn run_update() -> Result<(), Box<dyn std::error::Error>> {
     let latest = check_latest_version().await?;
 
     if !is_newer(&latest, CURRENT_VERSION) {
-        eprintln!("{}", crate::messages::update::already_latest(CURRENT_VERSION));
+        eprintln!(
+            "{}",
+            crate::messages::update::already_latest(CURRENT_VERSION)
+        );
         return Ok(());
     }
 
-    eprintln!("{}", crate::messages::update::updating(CURRENT_VERSION, &latest));
+    eprintln!(
+        "{}",
+        crate::messages::update::updating(CURRENT_VERSION, &latest)
+    );
 
     // Determine platform-specific asset name
     let asset_name = detect_asset_name()?;
-    let download_url = format!(
-        "https://github.com/{REPO}/releases/download/v{latest}/{asset_name}"
-    );
+    let download_url =
+        format!("https://github.com/{REPO}/releases/download/v{latest}/{asset_name}");
 
     // Download binary
     eprintln!("{}", crate::messages::update::downloading(&download_url));
@@ -234,9 +237,7 @@ fn schedule_deferred_replace(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::os::windows::process::CommandExt;
 
-    let tmp_dir = new_binary
-        .parent()
-        .ok_or("cannot resolve temp directory")?;
+    let tmp_dir = new_binary.parent().ok_or("cannot resolve temp directory")?;
     let script_path = std::env::temp_dir().join("rwd_update.cmd");
 
     let script = format!(
@@ -311,7 +312,12 @@ fn replace_binary_unix(
             }
 
             let move_status = std::process::Command::new("sudo")
-                .args(["mv", "-f", &staged.to_string_lossy(), &target.to_string_lossy()])
+                .args([
+                    "mv",
+                    "-f",
+                    &staged.to_string_lossy(),
+                    &target.to_string_lossy(),
+                ])
                 .status()?;
             if move_status.success() {
                 return Ok(());
@@ -390,10 +396,8 @@ mod tests {
     fn stage_and_rename_unix_replaces_target_atomically() {
         use std::os::unix::fs::PermissionsExt;
 
-        let temp_dir = std::env::temp_dir().join(format!(
-            "rwd_update_stage_test_{}",
-            std::process::id()
-        ));
+        let temp_dir =
+            std::env::temp_dir().join(format!("rwd_update_stage_test_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).expect("create temp dir");
 


### PR DESCRIPTION
## Summary\n- refine analysis/retry and provider flow in analyzer modules\n- extend cache and CLI flags for no-cache-aware summary/slack flows\n- improve markdown/output, redactor patterns, and update handling\n- add multi-root discovery design/next-session docs\n\n## Validation\n- cargo build\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test