### PR TITLE
chore: bump version to 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.12.1"
+version = "0.13.2"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"


### PR DESCRIPTION
Bump Cargo package version to 0.13.2 so Release On Main can publish a new tag/release.