### PR TITLE
chore: improve release note generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 changelog:
+  exclude:
+    labels:
+      - "skip-release-notes"
   categories:
-    - title: "Features"
+    - title: "New Features"
       labels: ["enhancement"]
     - title: "Bug Fixes"
       labels: ["bug"]

--- a/.github/scripts/generate_release_notes.cjs
+++ b/.github/scripts/generate_release_notes.cjs
@@ -1,0 +1,129 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function pluralize(count, noun) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function cleanTitle(title) {
+  const withoutPrefix = title.replace(/^\w+(?:\([^)]+\))?!?:\s*/, "");
+  return withoutPrefix.charAt(0).toUpperCase() + withoutPrefix.slice(1);
+}
+
+function extractPrNumbers(commits) {
+  const numbers = new Set();
+
+  for (const commit of commits) {
+    const subject = commit.commit.message.split("\n")[0];
+    const match =
+      subject.match(/Merge pull request #(\d+)/) ??
+      subject.match(/\(#(\d+)\)$/);
+
+    if (match) {
+      numbers.add(Number(match[1]));
+    }
+  }
+
+  return [...numbers];
+}
+
+function bucketFor(pr) {
+  const labels = new Set(pr.labels.map((label) => label.name));
+
+  if (labels.has("enhancement")) return "New Features";
+  if (labels.has("bug")) return "Bug Fixes";
+  if (labels.has("performance")) return "Performance";
+  if (labels.has("documentation")) return "Documentation";
+  return "Maintenance";
+}
+
+module.exports = async ({ github, context, core }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const tagName = process.env.TAG_NAME;
+  const targetSha = process.env.TARGET_SHA;
+  const previousTag = process.env.PREVIOUS_TAG;
+  const outputPath = path.join(process.env.GITHUB_WORKSPACE, "release-notes-intro.md");
+  const categories = new Map([
+    ["New Features", []],
+    ["Bug Fixes", []],
+    ["Performance", []],
+    ["Documentation", []],
+    ["Maintenance", []],
+  ]);
+  const summaryNouns = {
+    "New Features": "feature",
+    "Bug Fixes": "bug fix",
+    Performance: "performance update",
+    Documentation: "documentation update",
+    Maintenance: "maintenance change",
+  };
+
+  let commits = [];
+  if (previousTag) {
+    const { data } = await github.rest.repos.compareCommitsWithBasehead({
+      owner,
+      repo,
+      basehead: `${previousTag}...${targetSha}`,
+    });
+    commits = data.commits;
+  }
+
+  for (const pull_number of extractPrNumbers(commits)) {
+    const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+    const skip = pr.labels.some((label) => label.name === "skip-release-notes");
+    if (!skip) {
+      categories.get(bucketFor(pr)).push(pr);
+    }
+  }
+
+  const totalPrs = [...categories.values()].reduce((sum, prs) => sum + prs.length, 0);
+  const summaryParts = [...categories.entries()]
+    .filter(([, prs]) => prs.length > 0)
+    .map(([title, prs]) => pluralize(prs.length, summaryNouns[title]));
+
+  const lines = [
+    "## Release Notes",
+    "",
+    totalPrs
+      ? `This release includes ${summaryParts.join(", ")} across ${pluralize(totalPrs, "merged PR")}.`
+      : "This release packages the latest `rwd` changes with the project's structured release-note format.",
+    "",
+  ];
+
+  const featurePrs = categories.get("New Features") ?? [];
+  if (featurePrs.length) {
+    lines.push("### New Features");
+    for (const pr of featurePrs.slice(0, 3)) {
+      lines.push(`- ${cleanTitle(pr.title)} (#${pr.number})`);
+    }
+    if (featurePrs.length > 3) {
+      lines.push(`- Plus ${pluralize(featurePrs.length - 3, "more PR")} in this category.`);
+    }
+    lines.push("");
+  }
+
+  lines.push("### Highlights");
+  if (previousTag) {
+    lines.push(`- Compared against \`${previousTag}\` to keep the summary scoped to this release.`);
+  }
+  lines.push(`- Tagged as \`${tagName}\` from commit \`${targetSha.slice(0, 7)}\`.`);
+  lines.push("- Install with `cargo install --git https://github.com/gigagookbob/rwd.git` or update with `rwd update`.");
+  lines.push("");
+
+  for (const [title, prs] of categories) {
+    if (title === "New Features" || !prs.length) continue;
+
+    lines.push(`### ${title}`);
+    for (const pr of prs.slice(0, 3)) {
+      lines.push(`- ${cleanTitle(pr.title)} (#${pr.number})`);
+    }
+    if (prs.length > 3) {
+      lines.push(`- Plus ${pluralize(prs.length - 3, "more PR")} in this category.`);
+    }
+    lines.push("");
+  }
+
+  fs.writeFileSync(outputPath, lines.join("\n"));
+  core.notice(`Wrote structured release intro to ${outputPath}`);
+};

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
+            const headRef = context.payload.pull_request.head.ref;
             const prefixMap = {
               'feat':  'enhancement',
               'fix':   'bug',
@@ -27,16 +28,25 @@ jobs:
               'test':  'chore',
             };
 
-            const match = title.match(/^(\w+)(\(.+\))?[!]?:/);
-            if (!match) return;
+            const labels = [];
+            if (/^chore\/release-v\d+\.\d+\.\d+$/.test(headRef)) {
+              labels.push('skip-release-notes');
+            }
 
-            const prefix = match[1];
-            const label = prefixMap[prefix];
-            if (!label) return;
+            const match = title.match(/^(\w+)(\(.+\))?[!]?:/);
+            if (match) {
+              const prefix = match[1];
+              const label = prefixMap[prefix];
+              if (label) {
+                labels.push(label);
+              }
+            }
+
+            if (labels.length === 0) return;
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: [label],
+              labels: [...new Set(labels)],
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,16 +86,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve previous tag
+        id: previous_tag
+        run: |
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep '^v' | grep -Fxv "${{ inputs.tag_name }}" | head -n1 || true)
+          echo "previous_tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
 
+      - name: Generate release note intro
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.previous_tag }}
+        with:
+          script: |
+            const generate = require('./.github/scripts/generate_release_notes.cjs');
+            await generate({ github, context, core });
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          name: rwd ${{ inputs.tag_name }}
           tag_name: ${{ inputs.tag_name }}
           target_commitish: ${{ inputs.target_sha }}
+          body_path: release-notes-intro.md
           generate_release_notes: true
           files: |
             rwd-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ rwd update             # Update to the latest version
 - Release tag is derived from `Cargo.toml` package version (`vX.Y.Z`).
 - If the tag already exists, release is skipped.
 - Docs-only changes (for example `README.md`, `docs/**`) do not trigger release.
+- Release notes are published in two layers: a short custom summary for `rwd`, then GitHub's full categorized changelog.
+- Maintainer tone and workflow guide: [docs/RELEASES.md](docs/RELEASES.md)
 
 ## Uninstall
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,77 @@
+# Release Notes Guide — rwd
+
+## Goal
+
+`rwd` release notes should feel polished, calm, and useful.
+We want the tone of a product changelog, but scaled to a small Rust CLI project.
+
+## Preferred Shape
+
+Each GitHub Release should have two layers.
+
+1. Structured summary
+   - One-sentence overview
+   - `New Features` section when applicable
+   - `Highlights` section
+   - Small category sections such as `Bug Fixes`
+   - Upgrade/install reminder
+2. Auto-generated details
+   - Full PR list from GitHub release notes
+   - Contributors and compare links handled by GitHub
+
+This keeps the top of the release readable while still preserving a full audit trail below.
+
+## Writing Rules
+
+- Start with what changed for the user, not how it was implemented.
+- Use counts when they clarify scope, not to exaggerate impact.
+- Keep the custom summary short enough to scan in under a minute.
+- Let GitHub's generated section carry the exhaustive list.
+- Exclude release-only chores such as version bump PRs.
+- If setup, config, or behavior changed, mention it in `Highlights`.
+
+## Category Mapping
+
+| PR label | Release section |
+| --- | --- |
+| `enhancement` | `New Features` |
+| `bug` | `Bug Fixes` |
+| `performance` | `Performance` |
+| `documentation` | `Documentation` |
+| `chore`, `dependencies` | `Maintenance` |
+| `skip-release-notes` | Excluded from release notes |
+
+## Example Tone
+
+```md
+## Release Notes
+
+This release focuses on session discovery reliability and cleaner daily summaries.
+
+### New Features
+- support multi-root Claude/Codex log discovery (#85)
+
+### Highlights
+- Compared against `v0.13.1` to keep the summary scoped to this release.
+- Install with `cargo install --git https://github.com/gigagookbob/rwd.git` or update with `rwd update`.
+
+### Bug Fixes
+- parse GitHub release tag_name correctly in installer (#84)
+```
+
+## Maintainer Workflow
+
+- `Cargo.toml` version bump still defines the release tag (`vX.Y.Z`).
+- `.github/scripts/generate_release_notes.cjs` writes the structured summary.
+- `.github/release.yml` controls the GitHub-generated categories.
+- PRs opened from `chore/release-vX.Y.Z` branches get `skip-release-notes` automatically.
+
+## When to Edit Manually
+
+The automated summary is the default.
+After publishing, it is still worth editing the release body by hand when:
+
+- a release contains behavior changes that users must react to,
+- a release introduces a new command or config key,
+- a release fixes a subtle data-loss or correctness bug,
+- or the automatic bullets miss the real story of the release.


### PR DESCRIPTION
## Summary
- add a custom release-note intro generator so GitHub releases start with a short `rwd`-specific summary
- update release workflows and release categories to follow the new format and exclude release-only PRs
- document the maintainer-facing release note structure in `docs/RELEASES.md`

## Why
The project already had automatic GitHub releases, but the generated notes were closer to the default changelog than the product-style release notes we wanted. This PR keeps the automation while making the top of each release easier to scan.

## Impact
- future releases will open with `Release Notes`, `New Features`, `Highlights`, and `Bug Fixes` style sections when applicable
- release bump PRs from `chore/release-vX.Y.Z` branches will be excluded from the visible release summary
- maintainers now have a written guide for when to rely on automation vs. when to edit release notes manually

## Validation
- `cargo build`
- `cargo clippy`
- `cargo test`
- local sample generation for `v0.13.2`
