### PR TITLE
chore: promote dev to main for v0.13.3

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 changelog:
+  exclude:
+    labels:
+      - "skip-release-notes"
   categories:
-    - title: "Features"
+    - title: "New Features"
       labels: ["enhancement"]
     - title: "Bug Fixes"
       labels: ["bug"]

--- a/.github/scripts/generate_release_notes.cjs
+++ b/.github/scripts/generate_release_notes.cjs
@@ -1,0 +1,129 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function pluralize(count, noun) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function cleanTitle(title) {
+  const withoutPrefix = title.replace(/^\w+(?:\([^)]+\))?!?:\s*/, "");
+  return withoutPrefix.charAt(0).toUpperCase() + withoutPrefix.slice(1);
+}
+
+function extractPrNumbers(commits) {
+  const numbers = new Set();
+
+  for (const commit of commits) {
+    const subject = commit.commit.message.split("\n")[0];
+    const match =
+      subject.match(/Merge pull request #(\d+)/) ??
+      subject.match(/\(#(\d+)\)$/);
+
+    if (match) {
+      numbers.add(Number(match[1]));
+    }
+  }
+
+  return [...numbers];
+}
+
+function bucketFor(pr) {
+  const labels = new Set(pr.labels.map((label) => label.name));
+
+  if (labels.has("enhancement")) return "New Features";
+  if (labels.has("bug")) return "Bug Fixes";
+  if (labels.has("performance")) return "Performance";
+  if (labels.has("documentation")) return "Documentation";
+  return "Maintenance";
+}
+
+module.exports = async ({ github, context, core }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const tagName = process.env.TAG_NAME;
+  const targetSha = process.env.TARGET_SHA;
+  const previousTag = process.env.PREVIOUS_TAG;
+  const outputPath = path.join(process.env.GITHUB_WORKSPACE, "release-notes-intro.md");
+  const categories = new Map([
+    ["New Features", []],
+    ["Bug Fixes", []],
+    ["Performance", []],
+    ["Documentation", []],
+    ["Maintenance", []],
+  ]);
+  const summaryNouns = {
+    "New Features": "feature",
+    "Bug Fixes": "bug fix",
+    Performance: "performance update",
+    Documentation: "documentation update",
+    Maintenance: "maintenance change",
+  };
+
+  let commits = [];
+  if (previousTag) {
+    const { data } = await github.rest.repos.compareCommitsWithBasehead({
+      owner,
+      repo,
+      basehead: `${previousTag}...${targetSha}`,
+    });
+    commits = data.commits;
+  }
+
+  for (const pull_number of extractPrNumbers(commits)) {
+    const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+    const skip = pr.labels.some((label) => label.name === "skip-release-notes");
+    if (!skip) {
+      categories.get(bucketFor(pr)).push(pr);
+    }
+  }
+
+  const totalPrs = [...categories.values()].reduce((sum, prs) => sum + prs.length, 0);
+  const summaryParts = [...categories.entries()]
+    .filter(([, prs]) => prs.length > 0)
+    .map(([title, prs]) => pluralize(prs.length, summaryNouns[title]));
+
+  const lines = [
+    "## Release Notes",
+    "",
+    totalPrs
+      ? `This release includes ${summaryParts.join(", ")} across ${pluralize(totalPrs, "merged PR")}.`
+      : "This release packages the latest `rwd` changes with the project's structured release-note format.",
+    "",
+  ];
+
+  const featurePrs = categories.get("New Features") ?? [];
+  if (featurePrs.length) {
+    lines.push("### New Features");
+    for (const pr of featurePrs.slice(0, 3)) {
+      lines.push(`- ${cleanTitle(pr.title)} (#${pr.number})`);
+    }
+    if (featurePrs.length > 3) {
+      lines.push(`- Plus ${pluralize(featurePrs.length - 3, "more PR")} in this category.`);
+    }
+    lines.push("");
+  }
+
+  lines.push("### Highlights");
+  if (previousTag) {
+    lines.push(`- Compared against \`${previousTag}\` to keep the summary scoped to this release.`);
+  }
+  lines.push(`- Tagged as \`${tagName}\` from commit \`${targetSha.slice(0, 7)}\`.`);
+  lines.push("- Install with `cargo install --git https://github.com/gigagookbob/rwd.git` or update with `rwd update`.");
+  lines.push("");
+
+  for (const [title, prs] of categories) {
+    if (title === "New Features" || !prs.length) continue;
+
+    lines.push(`### ${title}`);
+    for (const pr of prs.slice(0, 3)) {
+      lines.push(`- ${cleanTitle(pr.title)} (#${pr.number})`);
+    }
+    if (prs.length > 3) {
+      lines.push(`- Plus ${pluralize(prs.length - 3, "more PR")} in this category.`);
+    }
+    lines.push("");
+  }
+
+  fs.writeFileSync(outputPath, lines.join("\n"));
+  core.notice(`Wrote structured release intro to ${outputPath}`);
+};

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
+            const headRef = context.payload.pull_request.head.ref;
             const prefixMap = {
               'feat':  'enhancement',
               'fix':   'bug',
@@ -27,16 +28,25 @@ jobs:
               'test':  'chore',
             };
 
-            const match = title.match(/^(\w+)(\(.+\))?[!]?:/);
-            if (!match) return;
+            const labels = [];
+            if (/^chore\/release-v\d+\.\d+\.\d+$/.test(headRef)) {
+              labels.push('skip-release-notes');
+            }
 
-            const prefix = match[1];
-            const label = prefixMap[prefix];
-            if (!label) return;
+            const match = title.match(/^(\w+)(\(.+\))?[!]?:/);
+            if (match) {
+              const prefix = match[1];
+              const label = prefixMap[prefix];
+              if (label) {
+                labels.push(label);
+              }
+            }
+
+            if (labels.length === 0) return;
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: [label],
+              labels: [...new Set(labels)],
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,16 +86,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve previous tag
+        id: previous_tag
+        run: |
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep '^v' | grep -Fxv "${{ inputs.tag_name }}" | head -n1 || true)
+          echo "previous_tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
 
+      - name: Generate release note intro
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+          TARGET_SHA: ${{ inputs.target_sha }}
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.previous_tag }}
+        with:
+          script: |
+            const generate = require('./.github/scripts/generate_release_notes.cjs');
+            await generate({ github, context, core });
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          name: rwd ${{ inputs.tag_name }}
           tag_name: ${{ inputs.tag_name }}
           target_commitish: ${{ inputs.target_sha }}
+          body_path: release-notes-intro.md
           generate_release_notes: true
           files: |
             rwd-*.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ rwd update             # Update to the latest version
 - Release tag is derived from `Cargo.toml` package version (`vX.Y.Z`).
 - If the tag already exists, release is skipped.
 - Docs-only changes (for example `README.md`, `docs/**`) do not trigger release.
+- Release notes are published in two layers: a short custom summary for `rwd`, then GitHub's full categorized changelog.
+- Maintainer tone and workflow guide: [docs/RELEASES.md](docs/RELEASES.md)
 
 ## Uninstall
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,77 @@
+# Release Notes Guide — rwd
+
+## Goal
+
+`rwd` release notes should feel polished, calm, and useful.
+We want the tone of a product changelog, but scaled to a small Rust CLI project.
+
+## Preferred Shape
+
+Each GitHub Release should have two layers.
+
+1. Structured summary
+   - One-sentence overview
+   - `New Features` section when applicable
+   - `Highlights` section
+   - Small category sections such as `Bug Fixes`
+   - Upgrade/install reminder
+2. Auto-generated details
+   - Full PR list from GitHub release notes
+   - Contributors and compare links handled by GitHub
+
+This keeps the top of the release readable while still preserving a full audit trail below.
+
+## Writing Rules
+
+- Start with what changed for the user, not how it was implemented.
+- Use counts when they clarify scope, not to exaggerate impact.
+- Keep the custom summary short enough to scan in under a minute.
+- Let GitHub's generated section carry the exhaustive list.
+- Exclude release-only chores such as version bump PRs.
+- If setup, config, or behavior changed, mention it in `Highlights`.
+
+## Category Mapping
+
+| PR label | Release section |
+| --- | --- |
+| `enhancement` | `New Features` |
+| `bug` | `Bug Fixes` |
+| `performance` | `Performance` |
+| `documentation` | `Documentation` |
+| `chore`, `dependencies` | `Maintenance` |
+| `skip-release-notes` | Excluded from release notes |
+
+## Example Tone
+
+```md
+## Release Notes
+
+This release focuses on session discovery reliability and cleaner daily summaries.
+
+### New Features
+- support multi-root Claude/Codex log discovery (#85)
+
+### Highlights
+- Compared against `v0.13.1` to keep the summary scoped to this release.
+- Install with `cargo install --git https://github.com/gigagookbob/rwd.git` or update with `rwd update`.
+
+### Bug Fixes
+- parse GitHub release tag_name correctly in installer (#84)
+```
+
+## Maintainer Workflow
+
+- `Cargo.toml` version bump still defines the release tag (`vX.Y.Z`).
+- `.github/scripts/generate_release_notes.cjs` writes the structured summary.
+- `.github/release.yml` controls the GitHub-generated categories.
+- PRs opened from `chore/release-vX.Y.Z` branches get `skip-release-notes` automatically.
+
+## When to Edit Manually
+
+The automated summary is the default.
+After publishing, it is still worth editing the release body by hand when:
+
+- a release contains behavior changes that users must react to,
+- a release introduces a new command or config key,
+- a release fixes a subtle data-loss or correctness bug,
+- or the automatic bullets miss the real story of the release.

--- a/src/analyzer/codex_exec.rs
+++ b/src/analyzer/codex_exec.rs
@@ -4,8 +4,9 @@
 
 use serde::Deserialize;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::{AnalyzerError, ApiUsage};
 
@@ -18,7 +19,16 @@ pub async fn call_codex_json_api(
     reasoning_effort: &str,
 ) -> Result<(String, ApiUsage), AnalyzerError> {
     let prompt = compose_prompt(system_prompt, conversation_text);
-    run_codex_exec(&prompt, None, max_tokens, model, reasoning_effort)
+    let schema_path = write_analysis_schema_file()?;
+    let result = run_codex_exec(
+        &prompt,
+        Some(schema_path.as_path()),
+        max_tokens,
+        model,
+        reasoning_effort,
+    );
+    let _ = std::fs::remove_file(schema_path);
+    result
 }
 
 /// Calls Codex for plain-text output (summary/slack/chunk summarize).
@@ -36,6 +46,77 @@ pub async fn call_codex_text_api(
 fn compose_prompt(system_prompt: &str, conversation_text: &str) -> String {
     format!("[System Instructions]\n{system_prompt}\n\n[Conversation]\n{conversation_text}")
 }
+
+/// Writes JSON schema for analysis output to a temporary file.
+/// Codex reads schemas from file paths (`--output-schema`), so we create one per request.
+fn write_analysis_schema_file() -> Result<PathBuf, AnalyzerError> {
+    let now_nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "rwd-analysis-schema-{}-{now_nanos}.json",
+        std::process::id()
+    ));
+    std::fs::write(&path, ANALYSIS_OUTPUT_SCHEMA)?;
+    Ok(path)
+}
+
+/// Structured output schema for insight extraction.
+const ANALYSIS_OUTPUT_SCHEMA: &str = r#"{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["sessions"],
+  "properties": {
+    "sessions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["session_id", "work_summary", "decisions", "curiosities", "corrections", "til"],
+        "properties": {
+          "session_id": { "type": "string" },
+          "work_summary": { "type": "string" },
+          "decisions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["what", "why"],
+              "properties": {
+                "what": { "type": "string" },
+                "why": { "type": "string" }
+              }
+            }
+          },
+          "curiosities": { "type": "array", "items": { "type": "string" } },
+          "corrections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["model_said", "user_corrected"],
+              "properties": {
+                "model_said": { "type": "string" },
+                "user_corrected": { "type": "string" }
+              }
+            }
+          },
+          "til": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["title", "detail"],
+              "properties": {
+                "title": { "type": "string" },
+                "detail": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"#;
 
 fn run_codex_exec(
     prompt: &str,
@@ -223,5 +304,13 @@ mod tests {
         let output = r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}"#;
         let result = parse_jsonl_events(output);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_write_analysis_schema_file_creates_schema_with_sessions_key() {
+        let path = write_analysis_schema_file().expect("schema file should be created");
+        let content = std::fs::read_to_string(&path).expect("schema file should be readable");
+        assert!(content.contains("\"sessions\""));
+        let _ = std::fs::remove_file(path);
     }
 }


### PR DESCRIPTION
## Summary
- promote `dev` into `main`
- includes JSON output schema enforcement for Codex analyzer
- includes version bump to `0.13.3`

## Validation already completed on dev
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
