### PR TITLE
fix: restore default release title format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: rwd ${{ inputs.tag_name }}
           tag_name: ${{ inputs.tag_name }}
           target_commitish: ${{ inputs.target_sha }}
           body_path: release-notes-intro.md


### PR DESCRIPTION
## Summary
- remove explicit release name prefix (`rwd `) from release workflow
- restore default tag-based release title behavior

## Validation
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
