### PR TITLE
release: v0.13.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: rwd ${{ inputs.tag_name }}
           tag_name: ${{ inputs.tag_name }}
           target_commitish: ${{ inputs.target_sha }}
           body_path: release-notes-intro.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -60,15 +60,22 @@ If you choose `codex`, `rwd` uses your existing `codex login` session (no API ke
 Obsidian vault is auto-detected if available.
 Config is stored at `~/.config/rwd/config.toml`.
 
+Auth methods by provider:
+- `anthropic`, `openai`: API key auth
+- `codex`: Codex login session auth (`codex login`)
+
 ### Change settings
 
 ```bash
 rwd config output-path /path/to/vault    # Change output path
 rwd config provider codex                # Change LLM provider
-rwd config api-key sk-...                # Change API key
+rwd config api-key sk-...                # Set API key for current provider (openai/anthropic)
+rwd config openai-api-key sk-...         # Set OpenAI API key directly
+rwd config anthropic-api-key sk-ant-...  # Set Anthropic API key directly
 rwd config codex-model gpt-5.4           # Override Codex model (default: gpt-5.4)
 rwd config codex-reasoning xhigh         # Override Codex reasoning (default: xhigh)
 rwd config lang ko                       # Change output language (en/ko)
+rwd auth status                          # Show provider auth method + credential state
 ```
 
 ### Sensitive data masking
@@ -88,6 +95,7 @@ rwd today --lang ko    # Override output language for this run
 rwd summary            # Generate progress summary (Markdown) → save + copy to clipboard
 rwd slack              # Generate Slack-ready message → copy to clipboard
 rwd config             # Change settings (interactive menu)
+rwd auth status        # Show current provider auth status
 rwd update             # Update to the latest version
 ```
 

--- a/src/analyzer/provider.rs
+++ b/src/analyzer/provider.rs
@@ -218,8 +218,8 @@ impl LlmProvider {
 pub fn load_provider() -> Result<(LlmProvider, String), super::AnalyzerError> {
     let config = crate::config::load_config_if_exists().ok_or(crate::messages::error::NO_CONFIG)?;
 
-    let provider = match config.llm.provider.as_str() {
-        "openai" => LlmProvider::OpenAi,
+    let (provider, api_key) = match config.llm.provider.as_str() {
+        "openai" => (LlmProvider::OpenAi, config.llm.openai_api_key.clone()),
         "codex" => {
             let model = config
                 .llm
@@ -233,12 +233,15 @@ pub fn load_provider() -> Result<(LlmProvider, String), super::AnalyzerError> {
                 .as_deref()
                 .unwrap_or(crate::config::DEFAULT_CODEX_REASONING_EFFORT)
                 .to_string();
-            LlmProvider::Codex {
-                model,
-                reasoning_effort,
-            }
+            (
+                LlmProvider::Codex {
+                    model,
+                    reasoning_effort,
+                },
+                String::new(),
+            )
         }
-        _ => LlmProvider::Anthropic,
+        _ => (LlmProvider::Anthropic, config.llm.anthropic_api_key.clone()),
     };
-    Ok((provider, config.llm.api_key))
+    Ok((provider, api_key))
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,10 @@ Examples:
   rwd config provider codex         Switch LLM provider
   rwd config codex-model gpt-5.4    Set Codex model
   rwd config codex-reasoning xhigh  Set Codex reasoning effort
-  rwd config api-key                Change API key
+  rwd config api-key sk-...         Set API key for current provider
+  rwd config openai-api-key sk-...  Set OpenAI API key
+  rwd config anthropic-api-key ...  Set Anthropic API key
+  rwd auth status                   Show provider auth status
   rwd update                        Update to the latest version"
 )]
 pub struct Cli {
@@ -97,14 +100,31 @@ Examples:
   rwd config                        Interactive settings menu
   rwd config output-path ~/vault    Set Obsidian vault path
   rwd config provider codex         Switch LLM provider
+  rwd config api-key sk-...         Set API key for current provider (openai/anthropic)
+  rwd config openai-api-key sk-...  Set OpenAI API key
+  rwd config anthropic-api-key ...  Set Anthropic API key
   rwd config codex-model gpt-5.4    Set Codex model
   rwd config codex-reasoning xhigh  Set Codex reasoning effort")]
     Config {
-        /// Config key (output-path, provider, api-key, codex-model, codex-reasoning)
+        /// Config key (output-path, provider, api-key, openai-api-key, anthropic-api-key, codex-model, codex-reasoning)
         key: Option<String>,
         /// Value to set
         value: Option<String>,
     },
     /// Update to the latest version via GitHub Releases
     Update,
+    /// Show authentication status for current provider
+    #[command(after_help = "\
+Example:
+  rwd auth status  Show provider auth method and credential state")]
+    Auth {
+        #[command(subcommand)]
+        action: AuthAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuthAction {
+    /// Show provider auth method and credential state
+    Status,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,11 +51,88 @@ impl Config {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LlmConfig {
     pub provider: String,
-    pub api_key: String,
+    #[serde(default)]
+    pub openai_api_key: String,
+    #[serde(default)]
+    pub anthropic_api_key: String,
+    /// Legacy single API key field (`api_key`) kept only for migration.
+    #[serde(default, rename = "api_key", skip_serializing)]
+    pub legacy_api_key: String,
     #[serde(default)]
     pub codex_model: Option<String>,
     #[serde(default)]
     pub codex_reasoning_effort: Option<String>,
+}
+
+impl LlmConfig {
+    /// Returns API key for the given provider.
+    fn api_key_for_provider(&self, provider: &str) -> &str {
+        match provider {
+            "openai" => &self.openai_api_key,
+            "anthropic" => &self.anthropic_api_key,
+            _ => "",
+        }
+    }
+
+    /// Sets API key for the given provider.
+    fn set_api_key_for_provider(&mut self, provider: &str, api_key: String) {
+        match provider {
+            "openai" => self.openai_api_key = api_key,
+            "anthropic" => self.anthropic_api_key = api_key,
+            _ => {}
+        }
+    }
+
+    /// Migrates legacy `api_key` into provider-specific key fields.
+    /// Returns true when migration changed in-memory values.
+    fn migrate_legacy_api_key(&mut self) -> bool {
+        let legacy = self.legacy_api_key.trim();
+        if legacy.is_empty() {
+            return false;
+        }
+
+        let mut changed = false;
+
+        // Infer provider from known key prefix first.
+        if legacy.starts_with("sk-ant-") {
+            if self.anthropic_api_key.is_empty() {
+                self.anthropic_api_key = legacy.to_string();
+                changed = true;
+            }
+        } else if legacy.starts_with("sk-") {
+            if self.openai_api_key.is_empty() {
+                self.openai_api_key = legacy.to_string();
+                changed = true;
+            }
+        } else {
+            match self.provider.as_str() {
+                "openai" => {
+                    if self.openai_api_key.is_empty() {
+                        self.openai_api_key = legacy.to_string();
+                        changed = true;
+                    }
+                }
+                "anthropic" => {
+                    if self.anthropic_api_key.is_empty() {
+                        self.anthropic_api_key = legacy.to_string();
+                        changed = true;
+                    }
+                }
+                _ => {
+                    if self.openai_api_key.is_empty() {
+                        self.openai_api_key = legacy.to_string();
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        if changed {
+            self.legacy_api_key.clear();
+        }
+
+        changed
+    }
 }
 
 /// Markdown output settings.
@@ -107,7 +184,11 @@ pub fn save_config(config: &Config, path: &std::path::Path) -> Result<(), Config
 /// Loads config from a TOML file.
 pub fn load_config(path: &std::path::Path) -> Result<Config, ConfigError> {
     let content = std::fs::read_to_string(path)?;
-    let config: Config = toml::from_str(&content)?;
+    let mut config: Config = toml::from_str(&content)?;
+    if config.llm.migrate_legacy_api_key() {
+        // Best-effort in-place migration to persist new key layout and drop legacy field.
+        let _ = save_config(&config, path);
+    }
     Ok(config)
 }
 
@@ -141,7 +222,7 @@ pub fn run_init() -> Result<(), ConfigError> {
     }
 
     // API key input (masked). Codex uses `codex login` auth (no API key).
-    let api_key = match provider {
+    let entered_api_key = match provider {
         "codex" => {
             eprintln!("{}", crate::messages::init::CODEX_LOGIN_AUTH);
             String::new()
@@ -159,14 +240,14 @@ pub fn run_init() -> Result<(), ConfigError> {
         _ => unreachable!(),
     };
 
-    if provider != "codex" && api_key.is_empty() {
+    if provider != "codex" && entered_api_key.is_empty() {
         return Err(crate::messages::init::API_KEY_EMPTY.into());
     }
 
     if provider != "codex" {
         // Show masked key (first 8 chars + ***)
-        let masked = if api_key.len() > 8 {
-            format!("{}***", &api_key[..8])
+        let masked = if entered_api_key.len() > 8 {
+            format!("{}***", &entered_api_key[..8])
         } else {
             "***".to_string()
         };
@@ -204,7 +285,17 @@ pub fn run_init() -> Result<(), ConfigError> {
     let config = Config {
         llm: LlmConfig {
             provider: provider.to_string(),
-            api_key,
+            openai_api_key: if provider == "openai" {
+                entered_api_key.clone()
+            } else {
+                String::new()
+            },
+            anthropic_api_key: if provider == "anthropic" {
+                entered_api_key
+            } else {
+                String::new()
+            },
+            legacy_api_key: String::new(),
             codex_model: None,
             codex_reasoning_effort: None,
         },
@@ -233,6 +324,7 @@ pub fn run_config(key: &str, value: &str) -> Result<(), ConfigError> {
     }
 
     let mut config = load_config(&config_file)?;
+    let old_provider = config.llm.provider.clone();
 
     match key {
         "output-path" => {
@@ -244,13 +336,43 @@ pub fn run_config(key: &str, value: &str) -> Result<(), ConfigError> {
                 return Err(crate::messages::config::unsupported_provider(value).into());
             }
             config.llm.provider = value.to_string();
-            eprintln!("{}", crate::messages::config::provider_changed(value));
+            eprintln!(
+                "{}",
+                crate::messages::config::provider_changed(value, provider_auth_method(value))
+            );
+            print_provider_switch_guidance(&old_provider, value, &config.llm);
         }
         "api-key" => {
-            config.llm.api_key = value.to_string();
+            if !provider_uses_api_key(&config.llm.provider) {
+                return Err(crate::messages::config::api_key_unused_for_provider(
+                    &config.llm.provider,
+                )
+                .into());
+            }
+            let provider = config.llm.provider.clone();
+            config
+                .llm
+                .set_api_key_for_provider(&provider, value.to_string());
             eprintln!(
                 "{}",
                 crate::messages::config::api_key_changed(&mask_api_key(value))
+            );
+        }
+        "openai-api-key" => {
+            config.llm.openai_api_key = value.to_string();
+            eprintln!(
+                "{}",
+                crate::messages::config::provider_api_key_changed("OpenAI", &mask_api_key(value))
+            );
+        }
+        "anthropic-api-key" => {
+            config.llm.anthropic_api_key = value.to_string();
+            eprintln!(
+                "{}",
+                crate::messages::config::provider_api_key_changed(
+                    "Anthropic",
+                    &mask_api_key(value),
+                )
             );
         }
         "codex-model" => {
@@ -324,6 +446,169 @@ fn parse_reasoning_effort(value: &str) -> Result<Option<String>, ConfigError> {
     } else {
         Err(crate::messages::config::unsupported_reasoning_effort(trimmed).into())
     }
+}
+
+fn provider_auth_method(provider: &str) -> &'static str {
+    match provider {
+        "codex" => "Codex login session",
+        "anthropic" | "openai" => "API key",
+        _ => "API key",
+    }
+}
+
+fn provider_uses_api_key(provider: &str) -> bool {
+    matches!(provider, "anthropic" | "openai")
+}
+
+fn has_stored_api_key(api_key: &str) -> bool {
+    !api_key.trim().is_empty()
+}
+
+fn provider_api_key<'a>(llm: &'a LlmConfig, provider: &str) -> &'a str {
+    llm.api_key_for_provider(provider)
+}
+
+fn print_provider_switch_guidance(old_provider: &str, new_provider: &str, llm: &LlmConfig) {
+    if old_provider == new_provider {
+        return;
+    }
+
+    if new_provider == "codex" {
+        let openai_state = if has_stored_api_key(&llm.openai_api_key) {
+            "set"
+        } else {
+            "not set"
+        };
+        let anthropic_state = if has_stored_api_key(&llm.anthropic_api_key) {
+            "set"
+        } else {
+            "not set"
+        };
+        eprintln!(
+            "{}",
+            crate::messages::config::switched_to_codex_keeps_api_key(&format!(
+                "openai: {openai_state}, anthropic: {anthropic_state}"
+            ))
+        );
+    } else if provider_uses_api_key(new_provider)
+        && !has_stored_api_key(provider_api_key(llm, new_provider))
+    {
+        eprintln!(
+            "{}",
+            crate::messages::config::provider_requires_api_key(new_provider)
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexLoginState {
+    Verified,
+    NotLoggedIn,
+    CheckFailed,
+}
+
+fn infer_codex_login_state(success: bool, stdout: &str, stderr: &str) -> CodexLoginState {
+    if !success {
+        return CodexLoginState::NotLoggedIn;
+    }
+
+    // Some Codex builds print login status to stderr instead of stdout.
+    let merged = format!("{stdout}\n{stderr}").to_ascii_lowercase();
+    if merged.contains("not logged in") || merged.contains("not authenticated") {
+        CodexLoginState::NotLoggedIn
+    } else if merged.contains("logged in") {
+        CodexLoginState::Verified
+    } else {
+        CodexLoginState::NotLoggedIn
+    }
+}
+
+async fn codex_login_state() -> CodexLoginState {
+    let status_output = tokio::task::spawn_blocking(|| {
+        std::process::Command::new("codex")
+            .args(["login", "status"])
+            .output()
+    })
+    .await;
+
+    match status_output {
+        Ok(Ok(output)) => infer_codex_login_state(
+            output.status.success(),
+            &String::from_utf8_lossy(&output.stdout),
+            &String::from_utf8_lossy(&output.stderr),
+        ),
+        _ => CodexLoginState::CheckFailed,
+    }
+}
+
+pub async fn run_auth_status() -> Result<(), ConfigError> {
+    let config_file = config_path()?;
+
+    if !config_file.exists() {
+        return Err(crate::messages::config::NO_CONFIG.into());
+    }
+
+    let config = load_config(&config_file)?;
+    let provider = config.llm.provider.as_str();
+    let openai_has_key = has_stored_api_key(&config.llm.openai_api_key);
+    let anthropic_has_key = has_stored_api_key(&config.llm.anthropic_api_key);
+
+    println!("{}", crate::messages::auth::provider(provider));
+    println!(
+        "{}",
+        crate::messages::auth::auth_method(provider_auth_method(provider))
+    );
+
+    let openai_detail = if provider == "openai" {
+        "active"
+    } else {
+        "inactive"
+    };
+    let anthropic_detail = if provider == "anthropic" {
+        "active"
+    } else {
+        "inactive"
+    };
+    println!(
+        "{}",
+        crate::messages::auth::provider_api_key(
+            "OpenAI",
+            if openai_has_key { "set" } else { "not set" },
+            openai_detail,
+        )
+    );
+    println!(
+        "{}",
+        crate::messages::auth::provider_api_key(
+            "Anthropic",
+            if anthropic_has_key { "set" } else { "not set" },
+            anthropic_detail,
+        )
+    );
+
+    if provider == "codex" {
+        let state = match codex_login_state().await {
+            CodexLoginState::Verified => "verified",
+            CodexLoginState::NotLoggedIn => "not logged in",
+            CodexLoginState::CheckFailed => "check failed",
+        };
+        println!("{}", crate::messages::auth::codex_login_status(state));
+    } else {
+        let has_active_key = has_stored_api_key(provider_api_key(&config.llm, provider));
+        if !has_active_key {
+            let hint = if provider == "openai" {
+                "set with `rwd config api-key <key>` or `rwd config openai-api-key <key>`"
+            } else {
+                "set with `rwd config api-key <key>` or `rwd config anthropic-api-key <key>`"
+            };
+            println!(
+                "{}",
+                crate::messages::auth::provider_missing_api_key(provider, hint)
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Reads a password with Esc support. Esc returns None (cancel), Enter returns the input.
@@ -408,29 +693,20 @@ async fn verify_api_key(provider: &str, api_key: &str) {
             "{dim}{}{reset}",
             crate::messages::verify::VERIFYING_CODEX_LOGIN
         );
-        let status_output = tokio::task::spawn_blocking(|| {
-            std::process::Command::new("codex")
-                .args(["login", "status"])
-                .output()
-        })
-        .await;
-
-        match status_output {
-            Ok(Ok(output)) => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                if output.status.success() && stdout.trim_start().starts_with("Logged in") {
-                    eprintln!(
-                        "\r{green}{}{reset}                    ",
-                        crate::messages::verify::CODEX_LOGIN_VERIFIED
-                    );
-                } else {
-                    eprintln!(
-                        "\r{yellow}{}{reset}",
-                        crate::messages::verify::CODEX_NOT_LOGGED_IN
-                    );
-                }
+        match codex_login_state().await {
+            CodexLoginState::Verified => {
+                eprintln!(
+                    "\r{green}{}{reset}                    ",
+                    crate::messages::verify::CODEX_LOGIN_VERIFIED
+                );
             }
-            _ => {
+            CodexLoginState::NotLoggedIn => {
+                eprintln!(
+                    "\r{yellow}{}{reset}",
+                    crate::messages::verify::CODEX_NOT_LOGGED_IN
+                );
+            }
+            CodexLoginState::CheckFailed => {
                 eprintln!(
                     "\r{dim}{}{reset}",
                     crate::messages::verify::CODEX_LOGIN_CHECK_FAILED
@@ -500,7 +776,9 @@ async fn verify_api_key(provider: &str, api_key: &str) {
 
 /// Masks an API key for display.
 fn mask_api_key(key: &str) -> String {
-    if key.len() > 8 {
+    if key.trim().is_empty() {
+        "not set".to_string()
+    } else if key.len() > 8 {
         format!("{}***", &key[..8])
     } else if key.len() > 4 {
         format!("{}***", &key[..4])
@@ -542,6 +820,12 @@ pub async fn run_config_interactive() -> Result<(), ConfigError> {
             .codex_reasoning_effort
             .as_deref()
             .unwrap_or(DEFAULT_CODEX_REASONING_EFFORT);
+        let current_provider_key = provider_api_key(&config.llm, &config.llm.provider);
+        let api_key_display = if provider_uses_api_key(&config.llm.provider) {
+            mask_api_key(current_provider_key)
+        } else {
+            "unused (codex login)".to_string()
+        };
         let items = vec![
             format!(
                 "{cyan}provider{reset}      {dim}[{}]{reset}",
@@ -549,7 +833,7 @@ pub async fn run_config_interactive() -> Result<(), ConfigError> {
             ),
             format!(
                 "{cyan}api-key{reset}       {dim}[{}]{reset}",
-                mask_api_key(&config.llm.api_key)
+                api_key_display
             ),
             format!("{cyan}codex-model{reset}   {dim}[{codex_model}]{reset}"),
             format!("{cyan}codex-reasoning{reset} {dim}[{codex_reasoning}]{reset}"),
@@ -608,7 +892,19 @@ pub async fn run_config_interactive() -> Result<(), ConfigError> {
                         "{green}{}{reset}",
                         crate::messages::config::changed(&old, new_provider)
                     );
-                    verify_api_key(&config.llm.provider, &config.llm.api_key).await;
+                    eprintln!(
+                        "{dim}{}{reset}",
+                        crate::messages::config::provider_now_uses(
+                            new_provider,
+                            provider_auth_method(new_provider),
+                        )
+                    );
+                    print_provider_switch_guidance(&old, new_provider, &config.llm);
+                    verify_api_key(
+                        &config.llm.provider,
+                        provider_api_key(&config.llm, &config.llm.provider),
+                    )
+                    .await;
                     eprintln!();
                 }
             }
@@ -636,17 +932,22 @@ pub async fn run_config_interactive() -> Result<(), ConfigError> {
                 if confirmed != Some(true) {
                     continue;
                 }
-                let old_masked = mask_api_key(&config.llm.api_key);
-                config.llm.api_key = new_key;
+                let old_masked = mask_api_key(provider_api_key(&config.llm, &config.llm.provider));
+                let provider = config.llm.provider.clone();
+                config.llm.set_api_key_for_provider(&provider, new_key);
                 save_config(&config, &config_file)?;
                 eprintln!(
                     "{green}{}{reset}",
                     crate::messages::config::changed(
                         &old_masked,
-                        &mask_api_key(&config.llm.api_key)
+                        &mask_api_key(provider_api_key(&config.llm, &config.llm.provider))
                     )
                 );
-                verify_api_key(&config.llm.provider, &config.llm.api_key).await;
+                verify_api_key(
+                    &config.llm.provider,
+                    provider_api_key(&config.llm, &config.llm.provider),
+                )
+                .await;
                 eprintln!();
             }
             // codex-model
@@ -993,7 +1294,9 @@ mod tests {
         let config = Config {
             llm: LlmConfig {
                 provider: "anthropic".to_string(),
-                api_key: "sk-test-key".to_string(),
+                openai_api_key: String::new(),
+                anthropic_api_key: "sk-test-key".to_string(),
+                legacy_api_key: String::new(),
                 codex_model: None,
                 codex_reasoning_effort: None,
             },
@@ -1009,7 +1312,8 @@ mod tests {
         let loaded = load_config(&path).expect("load");
 
         assert_eq!(loaded.llm.provider, "anthropic");
-        assert_eq!(loaded.llm.api_key, "sk-test-key");
+        assert_eq!(loaded.llm.openai_api_key, "");
+        assert_eq!(loaded.llm.anthropic_api_key, "sk-test-key");
         assert_eq!(loaded.llm.codex_model, None);
         assert_eq!(loaded.llm.codex_reasoning_effort, None);
         assert_eq!(loaded.output.path, "/tmp/vault");
@@ -1050,7 +1354,7 @@ mod tests {
         let toml_str = r#"
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1064,7 +1368,7 @@ path = "/tmp/vault"
         let toml_str = r#"
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1081,7 +1385,7 @@ enabled = false
         let toml_str = r#"
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1098,7 +1402,7 @@ lang = "ko"
 
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1114,7 +1418,7 @@ lang = "en"
 
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1128,7 +1432,7 @@ path = "/tmp/vault"
         let toml_str = r#"
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1142,7 +1446,7 @@ path = "/tmp/vault"
         let toml_str = r#"
 [llm]
 provider = "anthropic"
-api_key = "sk-test"
+anthropic_api_key = "sk-test"
 
 [output]
 path = "/tmp/vault"
@@ -1177,7 +1481,9 @@ claude_roots = ["/home/jinwoo/.claude/projects"]
         let config = Config {
             llm: LlmConfig {
                 provider: "anthropic".to_string(),
-                api_key: "sk-test".to_string(),
+                openai_api_key: String::new(),
+                anthropic_api_key: "sk-test".to_string(),
+                legacy_api_key: String::new(),
                 codex_model: None,
                 codex_reasoning_effort: None,
             },
@@ -1233,7 +1539,8 @@ claude_roots = ["/home/jinwoo/.claude/projects"]
         let toml_str = r#"
 [llm]
 provider = "codex"
-api_key = ""
+openai_api_key = ""
+anthropic_api_key = ""
 codex_model = "gpt-5.4"
 codex_reasoning_effort = "xhigh"
 
@@ -1244,6 +1551,58 @@ path = "/tmp/vault"
         assert_eq!(config.llm.provider, "codex");
         assert_eq!(config.llm.codex_model.as_deref(), Some("gpt-5.4"));
         assert_eq!(config.llm.codex_reasoning_effort.as_deref(), Some("xhigh"));
+    }
+
+    #[test]
+    fn test_load_config_migrates_legacy_openai_api_key() {
+        let temp_dir = std::env::temp_dir().join("rwd_test_legacy_key_openai");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).expect("create dir");
+        let path = temp_dir.join("config.toml");
+
+        let legacy_toml = r#"
+[llm]
+provider = "openai"
+api_key = "sk-openai-legacy"
+
+[output]
+path = "/tmp/vault"
+"#;
+        std::fs::write(&path, legacy_toml).expect("write legacy config");
+
+        let loaded = load_config(&path).expect("load config");
+        assert_eq!(loaded.llm.openai_api_key, "sk-openai-legacy");
+        assert_eq!(loaded.llm.anthropic_api_key, "");
+
+        let migrated = std::fs::read_to_string(&path).expect("read migrated config");
+        assert!(migrated.contains("openai_api_key = \"sk-openai-legacy\""));
+        assert!(!migrated.contains("\napi_key ="));
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_load_config_migrates_legacy_anthropic_key_by_prefix() {
+        let temp_dir = std::env::temp_dir().join("rwd_test_legacy_key_anthropic");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).expect("create dir");
+        let path = temp_dir.join("config.toml");
+
+        let legacy_toml = r#"
+[llm]
+provider = "codex"
+api_key = "sk-ant-legacy"
+
+[output]
+path = "/tmp/vault"
+"#;
+        std::fs::write(&path, legacy_toml).expect("write legacy config");
+
+        let loaded = load_config(&path).expect("load config");
+        assert_eq!(loaded.llm.openai_api_key, "");
+        assert_eq!(loaded.llm.anthropic_api_key, "sk-ant-legacy");
+
+        std::fs::remove_dir_all(&temp_dir).ok();
     }
 
     #[test]
@@ -1259,5 +1618,38 @@ path = "/tmp/vault"
     #[test]
     fn test_windows_path_to_wsl_rejects_non_windows_path() {
         assert!(windows_path_to_wsl("/home/alice/vault").is_none());
+    }
+
+    #[test]
+    fn test_provider_auth_method_and_usage_flags() {
+        assert_eq!(provider_auth_method("codex"), "Codex login session");
+        assert_eq!(provider_auth_method("openai"), "API key");
+        assert_eq!(provider_auth_method("anthropic"), "API key");
+        assert!(provider_uses_api_key("openai"));
+        assert!(provider_uses_api_key("anthropic"));
+        assert!(!provider_uses_api_key("codex"));
+    }
+
+    #[test]
+    fn test_has_stored_api_key_trims_whitespace() {
+        assert!(has_stored_api_key("sk-test-key"));
+        assert!(!has_stored_api_key(""));
+        assert!(!has_stored_api_key("   "));
+    }
+
+    #[test]
+    fn test_infer_codex_login_state_reads_stderr_logged_in() {
+        assert_eq!(
+            infer_codex_login_state(true, "", "Logged in using ChatGPT"),
+            CodexLoginState::Verified
+        );
+    }
+
+    #[test]
+    fn test_infer_codex_login_state_not_logged_in_phrase_wins() {
+        assert_eq!(
+            infer_codex_login_state(true, "Logged in", "Not logged in"),
+            CodexLoginState::NotLoggedIn
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod redactor;
 mod update;
 
 use clap::Parser;
-use cli::Commands;
+use cli::{AuthAction, Commands};
 
 // ANSI color codes — visible on both light and dark terminals.
 const CYAN: &str = "\x1b[36m";
@@ -102,6 +102,14 @@ async fn main() {
                 std::process::exit(1);
             }
         }
+        Commands::Auth { action } => match action {
+            AuthAction::Status => {
+                if let Err(e) = config::run_auth_status().await {
+                    eprintln!("{}", crate::messages::error::config_failed(&e));
+                    std::process::exit(1);
+                }
+            }
+        },
         Commands::Summary {
             lang,
             date,
@@ -1259,7 +1267,9 @@ mod tests {
         config::Config {
             llm: config::LlmConfig {
                 provider: "codex".to_string(),
-                api_key: String::new(),
+                openai_api_key: String::new(),
+                anthropic_api_key: String::new(),
+                legacy_api_key: String::new(),
                 codex_model: None,
                 codex_reasoning_effort: None,
             },
@@ -1287,7 +1297,8 @@ mod tests {
 
     #[test]
     fn test_collect_claude_entries_dedupes_across_roots() {
-        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("date");
+        // Use a far-future date to avoid collisions with real local logs.
+        let date = chrono::NaiveDate::from_ymd_opt(2099, 1, 1).expect("date");
         let base = unique_temp_dir("rwd_test_claude_multi_root");
         let root_a = base.join("claude-a");
         let root_b = base.join("claude-b");
@@ -1296,7 +1307,7 @@ mod tests {
         std::fs::create_dir_all(&project_a).expect("project a");
         std::fs::create_dir_all(&project_b).expect("project b");
 
-        let line = r#"{"type":"user","sessionId":"claude-session-1","timestamp":"2026-04-11T12:00:00Z","uuid":"same-entry"}"#;
+        let line = r#"{"type":"user","sessionId":"claude-session-1","timestamp":"2099-01-01T12:00:00Z","uuid":"same-entry"}"#;
         let file_a = project_a.join("session-a.jsonl");
         let file_b = project_b.join("session-b.jsonl");
         std::fs::write(&file_a, format!("{line}\n")).expect("write a");
@@ -1312,7 +1323,17 @@ mod tests {
         let (entries, stats) = collect_claude_entries_with_stats(date, Some(&cfg));
 
         assert!(stats.roots.starts_with(&[root_a.clone(), root_b.clone()]));
-        assert_eq!(entries.len(), 1);
+        let matching_count = entries
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    entry,
+                    parser::claude::LogEntry::User(u)
+                        if u.session_id == "claude-session-1" && u.uuid == "same-entry"
+                )
+            })
+            .count();
+        assert_eq!(matching_count, 1);
 
         std::fs::remove_dir_all(&base).ok();
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub const ENTER_API_KEY_ANTHROPIC: &str = "Enter Anthropic API key: ";
     pub const ENTER_API_KEY_OPENAI: &str = "Enter OpenAI API key: ";
     pub const CODEX_LOGIN_AUTH: &str =
-        "Codex provider uses `codex login` authentication (no API key needed).";
+        "Codex provider uses `codex login` session authentication (API key is not used).";
     pub const API_KEY_EMPTY: &str = "API key is empty.";
 
     pub fn api_key_input_failed(e: &dyn std::fmt::Display) -> String {
@@ -57,7 +57,7 @@ pub mod config {
     pub const NO_CHANGE: &str = "  No change";
     pub const NEW_API_KEY: &str = "  New API key: ";
     pub const CONFIRM_API_KEY: &str = "Change API key?";
-    pub const USAGE: &str = "Usage: `rwd config` (interactive) or `rwd config <key> <value>` (keys: output-path, provider, api-key, codex-model, codex-reasoning)";
+    pub const USAGE: &str = "Usage: `rwd config` (interactive) or `rwd config <key> <value>` (keys: output-path, provider, api-key, openai-api-key, anthropic-api-key, codex-model, codex-reasoning)";
 
     pub fn config_saved(path: &dyn std::fmt::Display) -> String {
         format!("Config saved. {path}")
@@ -71,12 +71,16 @@ pub mod config {
         format!("Output path changed: {value}")
     }
 
-    pub fn provider_changed(value: &str) -> String {
-        format!("LLM provider changed: {value}")
+    pub fn provider_changed(value: &str, auth_method: &str) -> String {
+        format!("LLM provider changed: {value} (auth: {auth_method})")
     }
 
     pub fn api_key_changed(masked: &str) -> String {
         format!("API key changed: {masked}")
+    }
+
+    pub fn provider_api_key_changed(provider: &str, masked: &str) -> String {
+        format!("{provider} API key changed: {masked}")
     }
 
     pub fn unsupported_provider(name: &str) -> String {
@@ -85,7 +89,7 @@ pub mod config {
 
     pub fn unknown_key(key: &str) -> String {
         format!(
-            "Unknown config key: '{key}'. Available: output-path, provider, api-key, codex-model, codex-reasoning"
+            "Unknown config key: '{key}'. Available: output-path, provider, api-key, openai-api-key, anthropic-api-key, codex-model, codex-reasoning"
         )
     }
 
@@ -97,10 +101,55 @@ pub mod config {
         format!("Codex reasoning effort changed: {value}")
     }
 
+    pub fn provider_now_uses(provider: &str, auth_method: &str) -> String {
+        format!("  Provider `{provider}` now uses: {auth_method}")
+    }
+
+    pub fn switched_to_codex_keeps_api_key(api_key_state: &str) -> String {
+        format!(
+            "  Switched to Codex login auth. Stored API key is kept ({api_key_state}) and unused."
+        )
+    }
+
+    pub fn provider_requires_api_key(provider: &str) -> String {
+        format!(
+            "  `{provider}` uses API key auth. Provider key is not set — set one with `rwd config api-key <key>`."
+        )
+    }
+
+    pub fn api_key_unused_for_provider(provider: &str) -> String {
+        format!(
+            "Current provider `{provider}` does not use API key auth. Use `rwd config provider openai|anthropic` first, or set `openai-api-key` / `anthropic-api-key` directly."
+        )
+    }
+
     pub fn unsupported_reasoning_effort(value: &str) -> String {
         format!(
             "Unsupported codex reasoning effort: '{value}'. Available: low, medium, high, xhigh, default"
         )
+    }
+}
+
+/// Messages for `rwd auth status`.
+pub mod auth {
+    pub fn provider(value: &str) -> String {
+        format!("Provider: {value}")
+    }
+
+    pub fn auth_method(value: &str) -> String {
+        format!("Auth method: {value}")
+    }
+
+    pub fn provider_api_key(provider: &str, state: &str, detail: &str) -> String {
+        format!("{provider} API key: {state} ({detail})")
+    }
+
+    pub fn codex_login_status(state: &str) -> String {
+        format!("Codex login: {state}")
+    }
+
+    pub fn provider_missing_api_key(provider: &str, hint: &str) -> String {
+        format!("{provider} API key status: missing ({hint})")
     }
 }
 


### PR DESCRIPTION
## Summary
- Promote current dev changes to main
- Bump package version from 0.13.3 to 0.13.4

## Validation
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

After merge, release-on-main will publish tag v0.13.4 automatically from Cargo.toml.
