### PR TITLE
chore: release v0.13.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ rwd answers **"What did I decide today, and why?"** — it extracts decisions, c
 curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash
 ```
 
+By default, this installs `rwd` to `~/.local/bin` (override with `RWD_INSTALL_DIR`).
+
+If you previously installed via `cargo install` or `/usr/local/bin`, keep only one binary in PATH:
+
+```bash
+cargo uninstall rwd
+sudo rm /usr/local/bin/rwd
+```
+
 ### One-line install (Windows)
 
 ```powershell
@@ -46,7 +55,7 @@ cargo install --git https://github.com/gigagookbob/rwd.git
 
 > If macOS shows "unidentified developer" warning:
 > ```bash
-> xattr -d com.apple.quarantine /usr/local/bin/rwd
+> xattr -d com.apple.quarantine ~/.local/bin/rwd
 > ```
 
 ## Setup
@@ -96,6 +105,7 @@ rwd summary            # Generate progress summary (Markdown) → save + copy to
 rwd slack              # Generate Slack-ready message → copy to clipboard
 rwd config             # Change settings (interactive menu)
 rwd auth status        # Show current provider auth status
+rwd doctor             # Diagnose PATH/install/config/session-root issues
 rwd update             # Update to the latest version
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/gigagookbob/rwd/main/install.sh | bash
 
 REPO="gigagookbob/rwd"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${RWD_INSTALL_DIR:-$HOME/.local/bin}"
 BINARY_NAME="rwd"
 
 # Fetch latest release tag.
@@ -74,6 +74,7 @@ if [ -z "$EXTRACTED" ]; then
 fi
 
 # Install binary
+mkdir -p "$INSTALL_DIR"
 chmod +x "$EXTRACTED"
 if [ -w "$INSTALL_DIR" ]; then
     mv "$EXTRACTED" "${INSTALL_DIR}/${BINARY_NAME}"
@@ -104,7 +105,7 @@ case ":${PATH}:" in
     *)
         echo ""
         echo "Note: ${INSTALL_DIR} is not in PATH for this shell."
-        echo "Add this line to ~/.bashrc, then restart your terminal:"
+        echo "Add this line to ~/.zshrc (or ~/.bashrc), then restart your terminal:"
         echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
         ;;
 esac

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,7 @@ Examples:
   rwd config openai-api-key sk-...  Set OpenAI API key
   rwd config anthropic-api-key ...  Set Anthropic API key
   rwd auth status                   Show provider auth status
+  rwd doctor                        Run environment and install diagnostics
   rwd update                        Update to the latest version"
 )]
 pub struct Cli {
@@ -121,6 +122,8 @@ Example:
         #[command(subcommand)]
         action: AuthAction,
     },
+    /// Run environment and install diagnostics
+    Doctor,
 }
 
 #[derive(Subcommand)]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,260 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CheckLevel {
+    Ok,
+    Warn,
+    Fail,
+}
+
+struct CheckResult {
+    name: &'static str,
+    level: CheckLevel,
+    lines: Vec<String>,
+}
+
+pub fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
+    let (path_check, active_binary) = check_binary_path()?;
+    let update_check = check_update_write_access(&active_binary)?;
+    let config_check = check_config_file()?;
+    let roots_check = check_log_roots();
+
+    let results = vec![path_check, update_check, config_check, roots_check];
+    print_report(&results);
+    Ok(())
+}
+
+fn check_binary_path() -> Result<(CheckResult, PathBuf), Box<dyn std::error::Error>> {
+    let binaries = visible_rwd_binaries();
+    if binaries.is_empty() {
+        let result = CheckResult {
+            name: "Binary discovery",
+            level: CheckLevel::Fail,
+            lines: vec!["No `rwd` binary found in PATH.".to_string()],
+        };
+        return Ok((result, std::env::current_exe()?));
+    }
+
+    let current_exe = std::env::current_exe()?;
+    let current_norm = normalized_path(&current_exe);
+    let active = if binaries
+        .iter()
+        .any(|candidate| normalized_path(candidate) == current_norm)
+    {
+        current_exe
+    } else {
+        binaries[0].clone()
+    };
+    let active_norm = normalized_path(&active);
+
+    let mut lines = vec![format!("Active binary: {}", active.display())];
+    let mut level = CheckLevel::Ok;
+
+    for candidate in &binaries {
+        if normalized_path(candidate) == active_norm {
+            continue;
+        }
+        level = CheckLevel::Warn;
+        let cleanup = cleanup_command_for_duplicate(candidate);
+        lines.push(format!(
+            "Duplicate found: {} (cleanup: {cleanup})",
+            candidate.display()
+        ));
+    }
+
+    Ok((
+        CheckResult {
+            name: "Binary discovery",
+            level,
+            lines,
+        },
+        active,
+    ))
+}
+
+fn visible_rwd_binaries() -> Vec<PathBuf> {
+    use std::collections::HashSet;
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut found = Vec::new();
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(binary_name());
+        if !candidate.is_file() {
+            continue;
+        }
+        let canonical = normalized_path(&candidate);
+        if seen.insert(canonical) {
+            found.push(candidate);
+        }
+    }
+    found
+}
+
+fn binary_name() -> &'static str {
+    if cfg!(windows) { "rwd.exe" } else { "rwd" }
+}
+
+fn normalized_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn cleanup_command_for_duplicate(path: &Path) -> String {
+    #[cfg(unix)]
+    {
+        if path == Path::new("/usr/local/bin/rwd") {
+            return "sudo rm /usr/local/bin/rwd".to_string();
+        }
+    }
+    if path.to_string_lossy().ends_with(".cargo/bin/rwd")
+        || path.to_string_lossy().ends_with(".cargo\\bin\\rwd.exe")
+    {
+        return "cargo uninstall rwd".to_string();
+    }
+    if cfg!(windows) {
+        format!("del {}", path.display())
+    } else {
+        format!("rm {}", path.display())
+    }
+}
+
+fn check_update_write_access(
+    active_binary: &Path,
+) -> Result<CheckResult, Box<dyn std::error::Error>> {
+    let Some(parent) = active_binary.parent() else {
+        return Ok(CheckResult {
+            name: "Update permissions",
+            level: CheckLevel::Fail,
+            lines: vec!["Cannot resolve the active binary directory.".to_string()],
+        });
+    };
+
+    let writable = can_write_to_dir(parent)?;
+    let (level, message) = if writable {
+        (
+            CheckLevel::Ok,
+            format!("Writable install directory: {}", parent.display()),
+        )
+    } else {
+        (
+            CheckLevel::Warn,
+            format!("Directory is not writable: {}", parent.display()),
+        )
+    };
+    Ok(CheckResult {
+        name: "Update permissions",
+        level,
+        lines: vec![message],
+    })
+}
+
+fn can_write_to_dir(dir: &Path) -> Result<bool, std::io::Error> {
+    use std::io::ErrorKind;
+    let probe = dir.join(format!(".rwd-doctor-{}", std::process::id()));
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)
+    {
+        Ok(_) => {
+            std::fs::remove_file(&probe).ok();
+            Ok(true)
+        }
+        Err(e) if e.kind() == ErrorKind::PermissionDenied => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+fn check_config_file() -> Result<CheckResult, Box<dyn std::error::Error>> {
+    let path = crate::config::config_path()?;
+    if !path.exists() {
+        return Ok(CheckResult {
+            name: "Config file",
+            level: CheckLevel::Warn,
+            lines: vec![format!(
+                "Missing config at {} (run `rwd init`).",
+                path.display()
+            )],
+        });
+    }
+
+    match crate::config::load_config(&path) {
+        Ok(config) => Ok(CheckResult {
+            name: "Config file",
+            level: CheckLevel::Ok,
+            lines: vec![format!(
+                "Config loaded: {} (provider: {})",
+                path.display(),
+                config.llm.provider
+            )],
+        }),
+        Err(e) => Ok(CheckResult {
+            name: "Config file",
+            level: CheckLevel::Fail,
+            lines: vec![format!("Config parse failed at {}: {e}", path.display())],
+        }),
+    }
+}
+
+fn check_log_roots() -> CheckResult {
+    let cfg = crate::config::load_config_if_exists();
+    let claude_overrides = cfg
+        .as_ref()
+        .and_then(|c| c.input.as_ref())
+        .and_then(|i| i.claude_roots.as_deref());
+    let codex_overrides = cfg
+        .as_ref()
+        .and_then(|c| c.input.as_ref())
+        .and_then(|i| i.codex_roots.as_deref());
+
+    let claude_roots = crate::parser::claude::discover_claude_log_roots(claude_overrides);
+    let codex_roots = crate::parser::codex::discover_codex_session_roots(codex_overrides);
+    if claude_roots.is_empty() && codex_roots.is_empty() {
+        return CheckResult {
+            name: "Session roots",
+            level: CheckLevel::Warn,
+            lines: vec!["No Claude/Codex log roots were discovered.".to_string()],
+        };
+    }
+
+    CheckResult {
+        name: "Session roots",
+        level: CheckLevel::Ok,
+        lines: vec![
+            format!("Claude Code roots: {}", claude_roots.len()),
+            format!("Codex roots: {}", codex_roots.len()),
+        ],
+    }
+}
+
+fn print_report(results: &[CheckResult]) {
+    println!("=== rwd doctor ===");
+    let mut ok = 0usize;
+    let mut warn = 0usize;
+    let mut fail = 0usize;
+
+    for result in results {
+        let marker = match result.level {
+            CheckLevel::Ok => {
+                ok += 1;
+                "OK"
+            }
+            CheckLevel::Warn => {
+                warn += 1;
+                "WARN"
+            }
+            CheckLevel::Fail => {
+                fail += 1;
+                "FAIL"
+            }
+        };
+        println!("[{marker}] {}", result.name);
+        for line in &result.lines {
+            println!("  - {line}");
+        }
+    }
+
+    println!("Summary: {ok} ok, {warn} warning, {fail} fail");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod analyzer;
 mod cache;
 mod cli;
 mod config;
+mod doctor;
 mod messages;
 mod output;
 mod parser;
@@ -32,7 +33,7 @@ async fn main() {
 
     // Show update notification only for synchronous commands.
     // Worker mode skips this to avoid blocking (no terminal).
-    let skip_update = matches!(args.command, Commands::Update)
+    let skip_update = matches!(args.command, Commands::Update | Commands::Doctor)
         || matches!(args.command, Commands::Today { worker: true, .. });
     if !skip_update {
         update::notify_if_update_available().await;
@@ -99,6 +100,12 @@ async fn main() {
         Commands::Update => {
             if let Err(e) = update::run_update().await {
                 eprintln!("{}", crate::messages::error::update_failed(&e));
+                std::process::exit(1);
+            }
+        }
+        Commands::Doctor => {
+            if let Err(e) = doctor::run_doctor() {
+                eprintln!("Error: {e}");
                 std::process::exit(1);
             }
         }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -430,6 +430,29 @@ pub mod update {
         format!("rwd v{version} update complete!")
     }
 
+    #[cfg(unix)]
+    pub fn user_bin_update_complete(path: &dyn std::fmt::Display, version: &str) -> String {
+        format!("rwd v{version} update complete! Installed to {path}")
+    }
+
+    #[cfg(unix)]
+    pub const USER_BIN_PATH_HINT: &str =
+        "Tip: ensure ~/.local/bin comes before system directories in PATH.";
+
+    #[cfg(unix)]
+    pub const DUPLICATE_BINARIES_FOUND: &str =
+        "Multiple `rwd` binaries are visible in PATH. Keep one to avoid confusion.";
+
+    #[cfg(unix)]
+    pub fn active_binary(path: &dyn std::fmt::Display) -> String {
+        format!("Active binary: {path}")
+    }
+
+    #[cfg(unix)]
+    pub fn cleanup_duplicate(path: &dyn std::fmt::Display, command: &str) -> String {
+        format!("Remove duplicate {path} with: {command}")
+    }
+
     #[cfg(windows)]
     pub fn update_deferred(version: &str) -> String {
         format!("Finalizing v{version} update...")

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 // Version check and self-update via GitHub Releases.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const REPO: &str = "gigagookbob/rwd";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -81,7 +81,11 @@ pub async fn run_update() -> Result<(), Box<dyn std::error::Error>> {
 
     let latest = check_latest_version().await?;
 
+    let current_exe = std::env::current_exe()?;
+
     if !is_newer(&latest, CURRENT_VERSION) {
+        #[cfg(unix)]
+        warn_duplicate_binaries_in_path(&current_exe);
         eprintln!(
             "{}",
             crate::messages::update::already_latest(CURRENT_VERSION)
@@ -126,8 +130,6 @@ pub async fn run_update() -> Result<(), Box<dyn std::error::Error>> {
     // Find extracted binary
     let extracted = find_binary_in_dir(&tmp_dir)?;
 
-    let current_exe = std::env::current_exe()?;
-
     // Update cache before potential process exit (Windows deferred path)
     let cache = crate::cache::UpdateCheckCache {
         checked_at: chrono::Utc::now(),
@@ -146,9 +148,19 @@ pub async fn run_update() -> Result<(), Box<dyn std::error::Error>> {
     // On Unix, replace in-place.
     #[cfg(unix)]
     {
-        replace_binary_unix(&extracted, &current_exe)?;
+        let user_target = replace_binary_unix(&extracted, &current_exe)?;
         std::fs::remove_dir_all(&tmp_dir).ok();
-        eprintln!("{}", crate::messages::update::update_complete(&latest));
+        let active_target = user_target.clone().unwrap_or_else(|| current_exe.clone());
+        if let Some(path) = user_target {
+            eprintln!(
+                "{}",
+                crate::messages::update::user_bin_update_complete(&path.display(), &latest)
+            );
+            eprintln!("{}", crate::messages::update::USER_BIN_PATH_HINT);
+        } else {
+            eprintln!("{}", crate::messages::update::update_complete(&latest));
+        }
+        warn_duplicate_binaries_in_path(&active_target);
     }
 
     #[allow(unreachable_code)]
@@ -279,13 +291,17 @@ fn schedule_deferred_replace(
 fn replace_binary_unix(
     new_binary: &std::path::Path,
     target: &std::path::Path,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(new_binary, std::fs::Permissions::from_mode(0o755))?;
 
     match stage_and_rename_unix(new_binary, target) {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(None),
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            if let Ok(Some(user_target)) = try_replace_in_user_bin(new_binary, target) {
+                return Ok(Some(user_target));
+            }
+
             eprintln!("{}", crate::messages::error::ADMIN_REQUIRED);
             // Privileged fallback: copy to sibling temp path, then atomic rename.
             let staged = target.with_extension("new");
@@ -320,12 +336,119 @@ fn replace_binary_unix(
                 ])
                 .status()?;
             if move_status.success() {
-                return Ok(());
+                return Ok(None);
             }
             Err(crate::messages::error::BINARY_REPLACE_FAILED.into())
         }
         Err(e) => Err(e.into()),
     }
+}
+
+#[cfg(unix)]
+fn try_replace_in_user_bin(
+    new_binary: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<Option<PathBuf>, std::io::Error> {
+    let home = match std::env::var_os("HOME") {
+        Some(home) => PathBuf::from(home),
+        None => return Ok(None),
+    };
+    let Some(user_target) = user_bin_target_for(target, &home) else {
+        return Ok(None);
+    };
+    let Some(parent) = user_target.parent() else {
+        return Ok(None);
+    };
+
+    std::fs::create_dir_all(parent)?;
+    stage_and_rename_unix(new_binary, &user_target)?;
+    Ok(Some(user_target))
+}
+
+#[cfg(unix)]
+fn user_bin_target_for(target: &std::path::Path, home: &std::path::Path) -> Option<PathBuf> {
+    let file_name = target.file_name()?;
+    let user_target = home.join(".local").join("bin").join(file_name);
+    if user_target == target {
+        return None;
+    }
+    Some(user_target)
+}
+
+#[cfg(unix)]
+fn warn_duplicate_binaries_in_path(active_binary: &Path) {
+    use std::collections::HashSet;
+
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return;
+    };
+
+    let mut seen = HashSet::new();
+    let mut visible = Vec::new();
+
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join("rwd");
+        if !candidate.is_file() {
+            continue;
+        }
+        let normalized = normalized_path(&candidate);
+        if !seen.insert(normalized.clone()) {
+            continue;
+        }
+        visible.push(candidate);
+    }
+
+    if visible.is_empty() {
+        return;
+    }
+
+    let requested_active = normalized_path(active_binary);
+    let active = if visible
+        .iter()
+        .any(|candidate| normalized_path(candidate) == requested_active)
+    {
+        active_binary.to_path_buf()
+    } else {
+        visible[0].clone()
+    };
+    let active_normalized = normalized_path(&active);
+    let duplicates: Vec<PathBuf> = visible
+        .into_iter()
+        .filter(|candidate| normalized_path(candidate) != active_normalized)
+        .collect();
+
+    if duplicates.is_empty() {
+        return;
+    }
+
+    eprintln!("{}", crate::messages::update::DUPLICATE_BINARIES_FOUND);
+    eprintln!(
+        "{}",
+        crate::messages::update::active_binary(&active.display())
+    );
+    for duplicate in duplicates {
+        let command = cleanup_command_for_duplicate(&duplicate);
+        eprintln!(
+            "{}",
+            crate::messages::update::cleanup_duplicate(&duplicate.display(), &command)
+        );
+    }
+}
+
+#[cfg(unix)]
+fn normalized_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(unix)]
+fn cleanup_command_for_duplicate(path: &Path) -> String {
+    if path == Path::new("/usr/local/bin/rwd") {
+        return "sudo rm /usr/local/bin/rwd".to_string();
+    }
+    if path.to_string_lossy().ends_with("/.cargo/bin/rwd") {
+        return "cargo uninstall rwd".to_string();
+    }
+    format!("rm {}", path.display())
 }
 
 #[cfg(unix)]
@@ -415,5 +538,42 @@ mod tests {
         assert_eq!(replaced, b"new-content");
 
         std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_bin_target_for_system_binary_returns_local_bin_path() {
+        let home = std::path::PathBuf::from("/Users/tester");
+        let target = std::path::PathBuf::from("/usr/local/bin/rwd");
+        let actual = super::user_bin_target_for(&target, &home).expect("target path");
+        assert_eq!(
+            actual,
+            std::path::PathBuf::from("/Users/tester/.local/bin/rwd")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_bin_target_for_same_path_returns_none() {
+        let home = std::path::PathBuf::from("/Users/tester");
+        let target = std::path::PathBuf::from("/Users/tester/.local/bin/rwd");
+        let actual = super::user_bin_target_for(&target, &home);
+        assert!(actual.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_command_for_usr_local_uses_sudo_remove() {
+        let path = std::path::PathBuf::from("/usr/local/bin/rwd");
+        let command = super::cleanup_command_for_duplicate(&path);
+        assert_eq!(command, "sudo rm /usr/local/bin/rwd");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_command_for_cargo_bin_uses_cargo_uninstall() {
+        let path = std::path::PathBuf::from("/Users/tester/.cargo/bin/rwd");
+        let command = super::cleanup_command_for_duplicate(&path);
+        assert_eq!(command, "cargo uninstall rwd");
     }
 }


### PR DESCRIPTION
## Summary
- bump package version from `0.13.4` to `0.13.5` for release
- includes previously merged `dev` changes (doctor command + install/update path improvements) when merged to `main`

## Validation
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
