### PR TITLE
chore: release v0.13.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"

--- a/src/parser/claude.rs
+++ b/src/parser/claude.rs
@@ -259,15 +259,20 @@ pub fn entry_timestamp(entry: &LogEntry) -> Option<DateTime<Utc>> {
 
 /// Filters entries to only those matching the given date (in local timezone).
 pub fn filter_entries_by_date(entries: Vec<LogEntry>, date: NaiveDate) -> Vec<LogEntry> {
+    let window = super::local_date_to_utc_window(date).ok();
+
     entries
         .into_iter()
-        .filter(|entry| {
-            // Convert UTC timestamp to local timezone before date comparison.
-            // This ensures entries are filtered by the user's local date, not UTC.
-            match entry_timestamp(entry) {
-                Some(ts) => ts.with_timezone(&chrono::Local).date_naive() == date,
-                None => false,
+        .filter(|entry| match entry_timestamp(entry) {
+            Some(ts) => {
+                if let Some(window) = window {
+                    window.contains(ts)
+                } else {
+                    // Fallback if local midnight resolution fails unexpectedly.
+                    ts.with_timezone(&chrono::Local).date_naive() == date
+                }
             }
+            None => false,
         })
         .collect()
 }

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -193,15 +193,14 @@ pub fn list_session_files_for_date(
     Ok(files)
 }
 
-/// Lists session files for a local date, scanning both the target date
-/// and previous day to handle UTC/local timezone offset.
+/// Lists session files for a local date by deriving the exact UTC date set
+/// touched by the local [00:00, next 00:00) window.
 pub fn list_session_files_for_local_date(
     sessions_dir: &Path,
     local_date: NaiveDate,
 ) -> Result<Vec<PathBuf>, super::ParseError> {
     let mut files = Vec::new();
-    let yesterday = local_date - chrono::Duration::days(1);
-    for date in [yesterday, local_date] {
+    for date in super::utc_dates_for_local_date(local_date)? {
         files.extend(list_session_files_for_date(sessions_dir, date)?);
     }
     Ok(files)
@@ -227,10 +226,20 @@ pub fn entry_timestamp(entry: &CodexEntry) -> Option<DateTime<Utc>> {
 /// SessionMeta entries are always preserved regardless of date, because
 /// they carry session metadata needed by `summarize_codex_entries`.
 pub fn filter_entries_by_local_date(entries: Vec<CodexEntry>, date: NaiveDate) -> Vec<CodexEntry> {
+    let window = super::local_date_to_utc_window(date).ok();
+
     entries
         .into_iter()
         .filter(|entry| {
-            matches!(entry, CodexEntry::SessionMeta { .. }) || entry_local_date(entry) == Some(date)
+            matches!(entry, CodexEntry::SessionMeta { .. })
+                || entry_timestamp(entry).is_some_and(|ts| {
+                    if let Some(window) = window {
+                        window.contains(ts)
+                    } else {
+                        // Fallback if local midnight resolution fails unexpectedly.
+                        ts.with_timezone(&chrono::Local).date_naive() == date
+                    }
+                })
         })
         .collect()
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,7 @@
 // Reads log files and transforms them into structured data.
 
+use chrono::{DateTime, Datelike, Local, NaiveDate, TimeZone, Utc};
+
 pub mod claude;
 pub mod roots;
 
@@ -10,7 +12,87 @@ pub mod codex;
 // TODO: Replace with a dedicated error type via thiserror.
 pub type ParseError = Box<dyn std::error::Error>;
 
+/// UTC half-open time window [start_utc, end_utc) for one local date.
+#[derive(Debug, Clone, Copy)]
+pub struct UtcDateWindow {
+    pub start_utc: DateTime<Utc>,
+    pub end_utc: DateTime<Utc>,
+}
+
+impl UtcDateWindow {
+    /// Returns true when a UTC timestamp is within [start_utc, end_utc).
+    pub fn contains(&self, ts: DateTime<Utc>) -> bool {
+        self.start_utc <= ts && ts < self.end_utc
+    }
+}
+
+/// Builds a UTC half-open window [local 00:00, next local 00:00) for a date.
+pub fn local_date_to_utc_window(local_date: NaiveDate) -> Result<UtcDateWindow, ParseError> {
+    let local_start = Local
+        .with_ymd_and_hms(local_date.year(), local_date.month(), local_date.day(), 0, 0, 0)
+        .earliest()
+        .ok_or_else(|| format!("Could not resolve local midnight for {local_date}"))?;
+
+    let next_date = local_date
+        .succ_opt()
+        .ok_or_else(|| format!("Could not compute next date from {local_date}"))?;
+
+    let local_end = Local
+        .with_ymd_and_hms(next_date.year(), next_date.month(), next_date.day(), 0, 0, 0)
+        .earliest()
+        .ok_or_else(|| format!("Could not resolve local midnight for {next_date}"))?;
+
+    let start_utc = local_start.with_timezone(&Utc);
+    let end_utc = local_end.with_timezone(&Utc);
+    if end_utc <= start_utc {
+        return Err(format!("Invalid UTC window for local date {local_date}").into());
+    }
+
+    Ok(UtcDateWindow { start_utc, end_utc })
+}
+
+/// Returns all UTC calendar dates touched by the given local date window.
+pub fn utc_dates_for_local_date(local_date: NaiveDate) -> Result<Vec<NaiveDate>, ParseError> {
+    let window = local_date_to_utc_window(local_date)?;
+    let mut dates = Vec::new();
+    let mut current = window.start_utc.date_naive();
+    let last_inclusive = (window.end_utc - chrono::Duration::nanoseconds(1)).date_naive();
+    while current <= last_inclusive {
+        dates.push(current);
+        current = current
+            .succ_opt()
+            .ok_or_else(|| format!("Could not advance UTC date from {current}"))?;
+    }
+    Ok(dates)
+}
+
 pub use claude::{
     dedupe_entries as dedupe_claude_entries, discover_claude_log_roots, filter_entries_by_date,
     list_project_dirs_in_root, list_session_files, parse_jsonl_file, summarize_entries,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_date_to_utc_window_contains_local_noon() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let window = local_date_to_utc_window(date).expect("utc window");
+        let local_noon = chrono::Local
+            .with_ymd_and_hms(2026, 4, 11, 12, 0, 0)
+            .earliest()
+            .expect("local noon");
+
+        assert!(window.contains(local_noon.with_timezone(&chrono::Utc)));
+    }
+
+    #[test]
+    fn test_utc_dates_for_local_date_has_small_bounded_set() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let dates = utc_dates_for_local_date(date).expect("utc dates");
+
+        assert!(!dates.is_empty());
+        assert!(dates.len() <= 3);
+    }
+}


### PR DESCRIPTION
## Summary
- release dev changes to main
- include UTC time-window filtering fix for local-day log analysis
- bump package version to 0.13.7 for release tagging

## Validation
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test