### PR TITLE
fix: invalidate daily cache when timezone day window changes

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,8 +29,39 @@ pub struct TodayCache {
     /// conversations continue inside existing sessions.
     #[serde(default)]
     pub codex_entry_count: usize,
+    /// Local-day UTC window key for cache safety across timezone changes.
+    ///
+    /// Format: "<start_utc_rfc3339>..<end_utc_rfc3339>".
+    /// Legacy caches may not have this field.
+    #[serde(default)]
+    pub timezone_window_key: Option<String>,
     /// Per-source analysis results.
     pub sources: Vec<(String, AnalysisResult)>,
+}
+
+/// Returns a timezone-aware cache identity for a local date.
+///
+/// The key is derived from the local [00:00, next 00:00) window represented in UTC.
+/// It changes when timezone/daylight-saving rules change.
+pub fn timezone_window_key(date: NaiveDate) -> Option<String> {
+    let window = crate::parser::local_date_to_utc_window(date).ok()?;
+    Some(format!(
+        "{}..{}",
+        window.start_utc.to_rfc3339(),
+        window.end_utc.to_rfc3339()
+    ))
+}
+
+/// Returns whether a cached result is compatible with the current local timezone rules.
+///
+/// Legacy caches without timezone metadata are treated as incompatible when the current
+/// key can be computed, forcing one-time refresh to prevent wrong cache reuse.
+pub fn is_timezone_compatible(cache: &TodayCache, date: NaiveDate) -> bool {
+    match timezone_window_key(date) {
+        Some(current_key) => cache.timezone_window_key.as_deref() == Some(current_key.as_str()),
+        // If the current timezone window cannot be resolved, fall back to existing behavior.
+        None => true,
+    }
 }
 
 /// Returns cache directory path: ~/.rwd/cache/
@@ -98,6 +129,17 @@ fn save_update_check_to(
 mod tests {
     use super::*;
 
+    fn empty_today_cache(date: &str, timezone_window_key: Option<String>) -> TodayCache {
+        TodayCache {
+            date: date.to_string(),
+            claude_entry_count: 0,
+            codex_session_count: 0,
+            codex_entry_count: 0,
+            timezone_window_key,
+            sources: Vec::new(),
+        }
+    }
+
     #[test]
     fn test_update_check_cache_serialize_deserialize_roundtrip() {
         let cache = UpdateCheckCache {
@@ -147,5 +189,36 @@ mod tests {
 }"#;
         let loaded: TodayCache = serde_json::from_str(json).expect("deserialize legacy cache");
         assert_eq!(loaded.codex_entry_count, 0);
+        assert!(loaded.timezone_window_key.is_none());
+    }
+
+    #[test]
+    fn test_timezone_window_key_has_start_and_end() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let key = timezone_window_key(date).expect("timezone window key");
+        let parts: Vec<&str> = key.split("..").collect();
+        assert_eq!(parts.len(), 2);
+        assert!(!parts[0].is_empty());
+        assert!(!parts[1].is_empty());
+    }
+
+    #[test]
+    fn test_is_timezone_compatible_requires_timezone_key() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let Some(current_key) = timezone_window_key(date) else {
+            // If timezone window resolution fails, compatibility falls back to true by design.
+            let cache = empty_today_cache("2026-04-11", None);
+            assert!(is_timezone_compatible(&cache, date));
+            return;
+        };
+
+        let legacy_cache = empty_today_cache("2026-04-11", None);
+        assert!(!is_timezone_compatible(&legacy_cache, date));
+
+        let compatible_cache = empty_today_cache("2026-04-11", Some(current_key.clone()));
+        assert!(is_timezone_compatible(&compatible_cache, date));
+
+        let incompatible_cache = empty_today_cache("2026-04-11", Some("wrong".to_string()));
+        assert!(!is_timezone_compatible(&incompatible_cache, date));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,22 +454,34 @@ async fn run_today(
     // Reuse previous analysis if the entry count is unchanged.
     if no_cache {
         println!("\n{}", crate::messages::status::CACHE_BYPASSED);
-    } else if let Some(cached) = cache::load_cache(today)
-        && cached.claude_entry_count == claude_count
-        && cached.codex_session_count == codex_session_count
-        && cached.codex_entry_count == codex_entry_count
-    {
-        println!("\n{}", crate::messages::status::CACHE_USED);
-        let source_refs: Vec<(&str, &analyzer::AnalysisResult)> = cached
-            .sources
-            .iter()
-            .map(|(name, result)| (name.as_str(), result))
-            .collect();
-        for (name, analysis) in &source_refs {
-            print_insights(name, analysis);
+    } else if let Some(cached) = cache::load_cache(today) {
+        let count_matches = cached.claude_entry_count == claude_count
+            && cached.codex_session_count == codex_session_count
+            && cached.codex_entry_count == codex_entry_count;
+        let timezone_matches = cache::is_timezone_compatible(&cached, today);
+
+        if count_matches && timezone_matches {
+            println!("\n{}", crate::messages::status::CACHE_USED);
+            let source_refs: Vec<(&str, &analyzer::AnalysisResult)> = cached
+                .sources
+                .iter()
+                .map(|(name, result)| (name.as_str(), result))
+                .collect();
+            for (name, analysis) in &source_refs {
+                print_insights(name, analysis);
+            }
+            save_combined_analysis(&source_refs, today, verbose);
+            return Ok(());
         }
-        save_combined_analysis(&source_refs, today, verbose);
-        return Ok(());
+
+        if count_matches && !timezone_matches {
+            eprintln!(
+                "{YELLOW}{}{RESET}",
+                crate::messages::status::CACHE_STALE_TIMEZONE
+            );
+            eprintln!("{}", crate::messages::status::CACHE_STALE_HINT);
+            eprintln!();
+        }
     }
 
     // === LLM analysis ===
@@ -528,6 +540,7 @@ async fn run_today(
             claude_entry_count: claude_count,
             codex_session_count,
             codex_entry_count,
+            timezone_window_key: cache::timezone_window_key(today),
             sources,
         };
         if let Err(e) = cache::save_cache(&cache_data, today) {
@@ -571,7 +584,7 @@ async fn run_summary(
         run_today(false, None, today, true).await?;
     }
 
-    let cached = match cache::load_cache(today) {
+    let mut cached = match cache::load_cache(today) {
         Some(c) => c,
         None => {
             println!("{}", crate::messages::error::NO_CACHE);
@@ -585,6 +598,23 @@ async fn run_summary(
             }
         }
     };
+
+    if !cache::is_timezone_compatible(&cached, today) {
+        eprintln!(
+            "{YELLOW}{}{RESET}",
+            crate::messages::status::CACHE_STALE_TIMEZONE
+        );
+        eprintln!("{}", crate::messages::status::CACHE_STALE_HINT);
+        eprintln!();
+        run_today(false, None, today, false).await?;
+        cached = match cache::load_cache(today) {
+            Some(c) => c,
+            None => {
+                eprintln!("{}", crate::messages::error::NO_CACHE_AFTER_ANALYSIS);
+                std::process::exit(1);
+            }
+        };
+    }
 
     // Concatenate all session work_summaries with source names for project-level grouping.
     let mut summaries_text = String::new();
@@ -634,7 +664,7 @@ async fn run_slack(
         run_today(false, None, today, true).await?;
     }
 
-    let cached = match cache::load_cache(today) {
+    let mut cached = match cache::load_cache(today) {
         Some(c) => c,
         None => {
             println!("{}", crate::messages::error::NO_CACHE);
@@ -648,6 +678,23 @@ async fn run_slack(
             }
         }
     };
+
+    if !cache::is_timezone_compatible(&cached, today) {
+        eprintln!(
+            "{YELLOW}{}{RESET}",
+            crate::messages::status::CACHE_STALE_TIMEZONE
+        );
+        eprintln!("{}", crate::messages::status::CACHE_STALE_HINT);
+        eprintln!();
+        run_today(false, None, today, false).await?;
+        cached = match cache::load_cache(today) {
+            Some(c) => c,
+            None => {
+                eprintln!("{}", crate::messages::error::NO_CACHE_AFTER_ANALYSIS);
+                std::process::exit(1);
+            }
+        };
+    }
 
     // Warn if cache is stale (entry count mismatch).
     let mut loaded_config = config::load_config_if_exists();

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -283,6 +283,9 @@ pub mod status {
         format!("\u{26A0} Cache is stale. (cached: {cached_total}, current: {current_total})")
     }
 
+    pub const CACHE_STALE_TIMEZONE: &str =
+        "\u{26A0} Cache is stale. (timezone/day boundary changed)";
+
     pub const CACHE_STALE_HINT: &str = "  Run `rwd today` first for up-to-date results.";
 
     pub fn markdown_saved(path: &dyn std::fmt::Display) -> String {


### PR DESCRIPTION
## Summary
- add timezone-aware cache key derived from local day UTC window
- invalidate stale cache reuse when timezone/day boundary changes
- refresh cache path for summary/slack when timezone compatibility fails

## Validation
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test