### PR TITLE
chore: switch spinner implementation to indicatif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +412,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -880,6 +892,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1181,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1487,9 +1518,10 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
- "console",
+ "console 0.15.11",
  "dialoguer",
  "dirs",
+ "indicatif",
  "notify-rust",
  "regex",
  "reqwest",
@@ -2007,6 +2039,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ console = "0.15"
 regex = "1"
 notify-rust = "4"
 semver = "1.0.27"
+indicatif = "0.18"
 
 [dev-dependencies]
 chrono-tz = "0.10"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -27,45 +27,36 @@ use crate::parser::codex::CodexEntry;
 use crate::redactor::RedactResult;
 use planner::{ExecutionPlan, StepStrategy};
 
-/// Starts a terminal spinner on stderr. Abort the returned handle to stop it.
-fn start_spinner(msg: String) -> tokio::task::JoinHandle<()> {
-    use std::io::Write;
-    tokio::spawn(async move {
-        let frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-        let mut i = 0;
-        loop {
-            eprint!("\r{} {}", frames[i % frames.len()], msg);
-            let _ = std::io::stderr().flush();
-            i += 1;
-            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
-        }
-    })
+/// Starts a terminal spinner on stderr.
+fn start_spinner(msg: String) -> indicatif::ProgressBar {
+    use indicatif::{ProgressBar, ProgressStyle};
+    use std::time::Duration;
+
+    let spinner = ProgressBar::new_spinner();
+    let style = ProgressStyle::with_template("{spinner} {msg}")
+        .unwrap_or_else(|_| ProgressStyle::default_spinner())
+        .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", ""]);
+    spinner.set_style(style);
+    spinner.set_message(msg);
+    spinner.enable_steady_tick(Duration::from_millis(80));
+    spinner
 }
 
 /// Stops the spinner and clears the line.
-fn stop_spinner(handle: tokio::task::JoinHandle<()>) {
-    handle.abort();
-    eprint!("\r\x1b[2K");
+fn stop_spinner(spinner: indicatif::ProgressBar) {
+    spinner.finish_and_clear();
 }
 
 /// Displays a countdown with spinner animation, updating every second.
 async fn countdown_sleep(total_secs: u64) {
-    use std::io::Write;
-    let frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-    let mut i = 0;
+    use std::time::Duration;
+
+    let spinner = start_spinner(crate::messages::status::countdown_waiting(total_secs));
     for remaining in (1..=total_secs).rev() {
-        for _ in 0..12 {
-            eprint!(
-                "\r{} {}",
-                frames[i % frames.len()],
-                crate::messages::status::countdown_waiting(remaining)
-            );
-            let _ = std::io::stderr().flush();
-            i += 1;
-            tokio::time::sleep(std::time::Duration::from_millis(83)).await;
-        }
+        spinner.set_message(crate::messages::status::countdown_waiting(remaining));
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    eprint!("\r\x1b[2K");
+    stop_spinner(spinner);
 }
 
 /// Main entry point: probes rate limits, plans execution, and runs LLM analysis.


### PR DESCRIPTION
## Summary
- Replace custom spinner implementation (`tokio::spawn + eprint`) with `indicatif` spinner
- Keep existing spinner frames/message behavior and clear-on-finish semantics
- Simplify countdown rendering by updating spinner message once per second
- Add `indicatif` dependency

## Why
- `indicatif` is the most widely adopted and actively maintained Rust CLI progress/spinner crate
- Reduces maintenance burden from manual terminal rendering logic

## Validation
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo run -- --help`
- `cargo run -- today --date 2000-01-01`
- `cargo run -- doctor`