### PR TITLE
chore: bump version to 0.13.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +412,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -880,6 +892,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1181,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1487,9 +1518,10 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
- "console",
+ "console 0.15.11",
  "dialoguer",
  "dirs",
+ "indicatif",
  "notify-rust",
  "regex",
  "reqwest",
@@ -2007,6 +2039,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1103,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1485,7 @@ name = "rwd"
 version = "0.13.7"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "clap",
  "console",
  "dialoguer",
@@ -1580,6 +1609,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ console = "0.15"
 regex = "1"
 notify-rust = "4"
 semver = "1.0.27"
+
+[dev-dependencies]
+chrono-tz = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ console = "0.15"
 regex = "1"
 notify-rust = "4"
 semver = "1.0.27"
+indicatif = "0.18"
 
 [dev-dependencies]
 chrono-tz = "0.10"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -27,45 +27,36 @@ use crate::parser::codex::CodexEntry;
 use crate::redactor::RedactResult;
 use planner::{ExecutionPlan, StepStrategy};
 
-/// Starts a terminal spinner on stderr. Abort the returned handle to stop it.
-fn start_spinner(msg: String) -> tokio::task::JoinHandle<()> {
-    use std::io::Write;
-    tokio::spawn(async move {
-        let frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-        let mut i = 0;
-        loop {
-            eprint!("\r{} {}", frames[i % frames.len()], msg);
-            let _ = std::io::stderr().flush();
-            i += 1;
-            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
-        }
-    })
+/// Starts a terminal spinner on stderr.
+fn start_spinner(msg: String) -> indicatif::ProgressBar {
+    use indicatif::{ProgressBar, ProgressStyle};
+    use std::time::Duration;
+
+    let spinner = ProgressBar::new_spinner();
+    let style = ProgressStyle::with_template("{spinner} {msg}")
+        .unwrap_or_else(|_| ProgressStyle::default_spinner())
+        .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", ""]);
+    spinner.set_style(style);
+    spinner.set_message(msg);
+    spinner.enable_steady_tick(Duration::from_millis(80));
+    spinner
 }
 
 /// Stops the spinner and clears the line.
-fn stop_spinner(handle: tokio::task::JoinHandle<()>) {
-    handle.abort();
-    eprint!("\r\x1b[2K");
+fn stop_spinner(spinner: indicatif::ProgressBar) {
+    spinner.finish_and_clear();
 }
 
 /// Displays a countdown with spinner animation, updating every second.
 async fn countdown_sleep(total_secs: u64) {
-    use std::io::Write;
-    let frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-    let mut i = 0;
+    use std::time::Duration;
+
+    let spinner = start_spinner(crate::messages::status::countdown_waiting(total_secs));
     for remaining in (1..=total_secs).rev() {
-        for _ in 0..12 {
-            eprint!(
-                "\r{} {}",
-                frames[i % frames.len()],
-                crate::messages::status::countdown_waiting(remaining)
-            );
-            let _ = std::io::stderr().flush();
-            i += 1;
-            tokio::time::sleep(std::time::Duration::from_millis(83)).await;
-        }
+        spinner.set_message(crate::messages::status::countdown_waiting(remaining));
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    eprint!("\r\x1b[2K");
+    stop_spinner(spinner);
 }
 
 /// Main entry point: probes rate limits, plans execution, and runs LLM analysis.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,8 +29,39 @@ pub struct TodayCache {
     /// conversations continue inside existing sessions.
     #[serde(default)]
     pub codex_entry_count: usize,
+    /// Local-day UTC window key for cache safety across timezone changes.
+    ///
+    /// Format: "<start_utc_rfc3339>..<end_utc_rfc3339>".
+    /// Legacy caches may not have this field.
+    #[serde(default)]
+    pub timezone_window_key: Option<String>,
     /// Per-source analysis results.
     pub sources: Vec<(String, AnalysisResult)>,
+}
+
+/// Returns a timezone-aware cache identity for a local date.
+///
+/// The key is derived from the local [00:00, next 00:00) window represented in UTC.
+/// It changes when timezone/daylight-saving rules change.
+pub fn timezone_window_key(date: NaiveDate) -> Option<String> {
+    let window = crate::parser::local_date_to_utc_window(date).ok()?;
+    Some(format!(
+        "{}..{}",
+        window.start_utc.to_rfc3339(),
+        window.end_utc.to_rfc3339()
+    ))
+}
+
+/// Returns whether a cached result is compatible with the current local timezone rules.
+///
+/// Legacy caches without timezone metadata are treated as incompatible when the current
+/// key can be computed, forcing one-time refresh to prevent wrong cache reuse.
+pub fn is_timezone_compatible(cache: &TodayCache, date: NaiveDate) -> bool {
+    match timezone_window_key(date) {
+        Some(current_key) => cache.timezone_window_key.as_deref() == Some(current_key.as_str()),
+        // If the current timezone window cannot be resolved, fall back to existing behavior.
+        None => true,
+    }
 }
 
 /// Returns cache directory path: ~/.rwd/cache/
@@ -98,6 +129,17 @@ fn save_update_check_to(
 mod tests {
     use super::*;
 
+    fn empty_today_cache(date: &str, timezone_window_key: Option<String>) -> TodayCache {
+        TodayCache {
+            date: date.to_string(),
+            claude_entry_count: 0,
+            codex_session_count: 0,
+            codex_entry_count: 0,
+            timezone_window_key,
+            sources: Vec::new(),
+        }
+    }
+
     #[test]
     fn test_update_check_cache_serialize_deserialize_roundtrip() {
         let cache = UpdateCheckCache {
@@ -147,5 +189,36 @@ mod tests {
 }"#;
         let loaded: TodayCache = serde_json::from_str(json).expect("deserialize legacy cache");
         assert_eq!(loaded.codex_entry_count, 0);
+        assert!(loaded.timezone_window_key.is_none());
+    }
+
+    #[test]
+    fn test_timezone_window_key_has_start_and_end() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let key = timezone_window_key(date).expect("timezone window key");
+        let parts: Vec<&str> = key.split("..").collect();
+        assert_eq!(parts.len(), 2);
+        assert!(!parts[0].is_empty());
+        assert!(!parts[1].is_empty());
+    }
+
+    #[test]
+    fn test_is_timezone_compatible_requires_timezone_key() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let Some(current_key) = timezone_window_key(date) else {
+            // If timezone window resolution fails, compatibility falls back to true by design.
+            let cache = empty_today_cache("2026-04-11", None);
+            assert!(is_timezone_compatible(&cache, date));
+            return;
+        };
+
+        let legacy_cache = empty_today_cache("2026-04-11", None);
+        assert!(!is_timezone_compatible(&legacy_cache, date));
+
+        let compatible_cache = empty_today_cache("2026-04-11", Some(current_key.clone()));
+        assert!(is_timezone_compatible(&compatible_cache, date));
+
+        let incompatible_cache = empty_today_cache("2026-04-11", Some("wrong".to_string()));
+        assert!(!is_timezone_compatible(&incompatible_cache, date));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,22 +454,34 @@ async fn run_today(
     // Reuse previous analysis if the entry count is unchanged.
     if no_cache {
         println!("\n{}", crate::messages::status::CACHE_BYPASSED);
-    } else if let Some(cached) = cache::load_cache(today)
-        && cached.claude_entry_count == claude_count
-        && cached.codex_session_count == codex_session_count
-        && cached.codex_entry_count == codex_entry_count
-    {
-        println!("\n{}", crate::messages::status::CACHE_USED);
-        let source_refs: Vec<(&str, &analyzer::AnalysisResult)> = cached
-            .sources
-            .iter()
-            .map(|(name, result)| (name.as_str(), result))
-            .collect();
-        for (name, analysis) in &source_refs {
-            print_insights(name, analysis);
+    } else if let Some(cached) = cache::load_cache(today) {
+        let count_matches = cached.claude_entry_count == claude_count
+            && cached.codex_session_count == codex_session_count
+            && cached.codex_entry_count == codex_entry_count;
+        let timezone_matches = cache::is_timezone_compatible(&cached, today);
+
+        if count_matches && timezone_matches {
+            println!("\n{}", crate::messages::status::CACHE_USED);
+            let source_refs: Vec<(&str, &analyzer::AnalysisResult)> = cached
+                .sources
+                .iter()
+                .map(|(name, result)| (name.as_str(), result))
+                .collect();
+            for (name, analysis) in &source_refs {
+                print_insights(name, analysis);
+            }
+            save_combined_analysis(&source_refs, today, verbose);
+            return Ok(());
         }
-        save_combined_analysis(&source_refs, today, verbose);
-        return Ok(());
+
+        if count_matches && !timezone_matches {
+            eprintln!(
+                "{YELLOW}{}{RESET}",
+                crate::messages::status::CACHE_STALE_TIMEZONE
+            );
+            eprintln!("{}", crate::messages::status::CACHE_STALE_HINT);
+            eprintln!();
+        }
     }
 
     // === LLM analysis ===
@@ -528,6 +540,7 @@ async fn run_today(
             claude_entry_count: claude_count,
             codex_session_count,
             codex_entry_count,
+            timezone_window_key: cache::timezone_window_key(today),
             sources,
         };
         if let Err(e) = cache::save_cache(&cache_data, today) {
@@ -571,7 +584,7 @@ async fn run_summary(
         run_today(false, None, today, true).await?;
     }
 
-    let cached = match cache::load_cache(today) {
+    let mut cached = match cache::load_cache(today) {
         Some(c) => c,
         None => {
             println!("{}", crate::messages::error::NO_CACHE);
@@ -585,6 +598,23 @@ async fn run_summary(
             }
         }
     };
+
+    if !cache::is_timezone_compatible(&cached, today) {
+        eprintln!(
+            "{YELLOW}{}{RESET}",
+            crate::messages::status::CACHE_STALE_TIMEZONE
+        );
+        eprintln!("{}", crate::messages::status::CACHE_STALE_HINT);
+        eprintln!();
+        run_today(false, None, today, false).await?;
+        cached = match cache::load_cache(today) {
+            Some(c) => c,
+            None => {
+                eprintln!("{}", crate::messages::error::NO_CACHE_AFTER_ANALYSIS);
+                std::process::exit(1);
+            }
+        };
+    }
 
     // Concatenate all session work_summaries with source names for project-level grouping.
     let mut summaries_text = String::new();
@@ -634,7 +664,7 @@ async fn run_slack(
         run_today(false, None, today, true).await?;
     }
 
-    let cached = match cache::load_cache(today) {
+    let mut cached = match cache::load_cache(today) {
         Some(c) => c,
         None => {
             println!("{}", crate::messages::error::NO_CACHE);
@@ -648,6 +678,23 @@ async fn run_slack(
             }
         }
     };
+
+    if !cache::is_timezone_compatible(&cached, today) {
+        eprintln!(
+            "{YELLOW}{}{RESET}",
+            crate::messages::status::CACHE_STALE_TIMEZONE
+        );
+        eprintln!("{}", crate::messages::status::CACHE_STALE_HINT);
+        eprintln!();
+        run_today(false, None, today, false).await?;
+        cached = match cache::load_cache(today) {
+            Some(c) => c,
+            None => {
+                eprintln!("{}", crate::messages::error::NO_CACHE_AFTER_ANALYSIS);
+                std::process::exit(1);
+            }
+        };
+    }
 
     // Warn if cache is stale (entry count mismatch).
     let mut loaded_config = config::load_config_if_exists();

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -283,6 +283,9 @@ pub mod status {
         format!("\u{26A0} Cache is stale. (cached: {cached_total}, current: {current_total})")
     }
 
+    pub const CACHE_STALE_TIMEZONE: &str =
+        "\u{26A0} Cache is stale. (timezone/day boundary changed)";
+
     pub const CACHE_STALE_HINT: &str = "  Run `rwd today` first for up-to-date results.";
 
     pub fn markdown_saved(path: &dyn std::fmt::Display) -> String {

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -727,4 +727,50 @@ mod tests {
         let filtered = filter_entries_by_local_date(entries, today_local);
         assert_eq!(filtered.len(), 4);
     }
+
+    #[test]
+    fn test_filter_entries_by_local_date_respects_half_open_window_boundaries() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let window = crate::parser::local_date_to_utc_window(date).expect("utc window");
+
+        let entries = vec![
+            CodexEntry::SessionMeta {
+                timestamp: window.start_utc,
+                session_id: "s1".to_string(),
+                cwd: "/p".to_string(),
+                model_provider: "openai".to_string(),
+            },
+            CodexEntry::UserMessage {
+                timestamp: window.start_utc - chrono::Duration::nanoseconds(1),
+                text: "before_start".to_string(),
+            },
+            CodexEntry::UserMessage {
+                timestamp: window.start_utc,
+                text: "at_start".to_string(),
+            },
+            CodexEntry::AssistantMessage {
+                timestamp: window.end_utc - chrono::Duration::nanoseconds(1),
+                text: "before_end".to_string(),
+            },
+            CodexEntry::AssistantMessage {
+                timestamp: window.end_utc,
+                text: "at_end".to_string(),
+            },
+        ];
+
+        let filtered = filter_entries_by_local_date(entries, date);
+        assert!(matches!(filtered[0], CodexEntry::SessionMeta { .. }));
+
+        let kept_texts: Vec<&str> = filtered
+            .iter()
+            .filter_map(|entry| match entry {
+                CodexEntry::UserMessage { text, .. } | CodexEntry::AssistantMessage { text, .. } => {
+                    Some(text.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(kept_texts, vec!["at_start", "before_end"]);
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,9 +26,11 @@ impl UtcDateWindow {
     }
 }
 
-/// Builds a UTC half-open window [local 00:00, next local 00:00) for a date.
-pub fn local_date_to_utc_window(local_date: NaiveDate) -> Result<UtcDateWindow, ParseError> {
-    let local_start = Local
+fn utc_window_for_date_in_timezone<Tz: TimeZone>(
+    local_date: NaiveDate,
+    timezone: &Tz,
+) -> Result<UtcDateWindow, ParseError> {
+    let local_start = timezone
         .with_ymd_and_hms(local_date.year(), local_date.month(), local_date.day(), 0, 0, 0)
         .earliest()
         .ok_or_else(|| format!("Could not resolve local midnight for {local_date}"))?;
@@ -37,7 +39,7 @@ pub fn local_date_to_utc_window(local_date: NaiveDate) -> Result<UtcDateWindow, 
         .succ_opt()
         .ok_or_else(|| format!("Could not compute next date from {local_date}"))?;
 
-    let local_end = Local
+    let local_end = timezone
         .with_ymd_and_hms(next_date.year(), next_date.month(), next_date.day(), 0, 0, 0)
         .earliest()
         .ok_or_else(|| format!("Could not resolve local midnight for {next_date}"))?;
@@ -51,9 +53,11 @@ pub fn local_date_to_utc_window(local_date: NaiveDate) -> Result<UtcDateWindow, 
     Ok(UtcDateWindow { start_utc, end_utc })
 }
 
-/// Returns all UTC calendar dates touched by the given local date window.
-pub fn utc_dates_for_local_date(local_date: NaiveDate) -> Result<Vec<NaiveDate>, ParseError> {
-    let window = local_date_to_utc_window(local_date)?;
+fn utc_dates_for_local_date_in_timezone<Tz: TimeZone>(
+    local_date: NaiveDate,
+    timezone: &Tz,
+) -> Result<Vec<NaiveDate>, ParseError> {
+    let window = utc_window_for_date_in_timezone(local_date, timezone)?;
     let mut dates = Vec::new();
     let mut current = window.start_utc.date_naive();
     let last_inclusive = (window.end_utc - chrono::Duration::nanoseconds(1)).date_naive();
@@ -66,6 +70,16 @@ pub fn utc_dates_for_local_date(local_date: NaiveDate) -> Result<Vec<NaiveDate>,
     Ok(dates)
 }
 
+/// Builds a UTC half-open window [local 00:00, next local 00:00) for a date.
+pub fn local_date_to_utc_window(local_date: NaiveDate) -> Result<UtcDateWindow, ParseError> {
+    utc_window_for_date_in_timezone(local_date, &Local)
+}
+
+/// Returns all UTC calendar dates touched by the given local date window.
+pub fn utc_dates_for_local_date(local_date: NaiveDate) -> Result<Vec<NaiveDate>, ParseError> {
+    utc_dates_for_local_date_in_timezone(local_date, &Local)
+}
+
 pub use claude::{
     dedupe_entries as dedupe_claude_entries, discover_claude_log_roots, filter_entries_by_date,
     list_project_dirs_in_root, list_session_files, parse_jsonl_file, summarize_entries,
@@ -74,6 +88,8 @@ pub use claude::{
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{Duration, FixedOffset, TimeZone};
+    use chrono_tz::America::New_York;
 
     #[test]
     fn test_local_date_to_utc_window_contains_local_noon() {
@@ -94,5 +110,83 @@ mod tests {
 
         assert!(!dates.is_empty());
         assert!(dates.len() <= 3);
+    }
+
+    #[test]
+    fn test_local_date_to_utc_window_is_half_open() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+        let window = local_date_to_utc_window(date).expect("utc window");
+
+        let just_before_start = window.start_utc - Duration::nanoseconds(1);
+        let just_before_end = window.end_utc - Duration::nanoseconds(1);
+
+        assert!(!window.contains(just_before_start));
+        assert!(window.contains(window.start_utc));
+        assert!(window.contains(just_before_end));
+        assert!(!window.contains(window.end_utc));
+    }
+
+    #[test]
+    fn test_utc_dates_for_local_date_in_utc_plus_14() {
+        let tz = FixedOffset::east_opt(14 * 3600).expect("UTC+14");
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+
+        let window = utc_window_for_date_in_timezone(date, &tz).expect("utc window");
+        assert_eq!(
+            window.start_utc,
+            chrono::Utc.with_ymd_and_hms(2026, 4, 10, 10, 0, 0).unwrap()
+        );
+        assert_eq!(
+            window.end_utc,
+            chrono::Utc.with_ymd_and_hms(2026, 4, 11, 10, 0, 0).unwrap()
+        );
+
+        let dates = utc_dates_for_local_date_in_timezone(date, &tz).expect("utc dates");
+        assert_eq!(
+            dates,
+            vec![
+                chrono::NaiveDate::from_ymd_opt(2026, 4, 10).expect("date"),
+                chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("date"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_utc_dates_for_local_date_in_utc_minus_12() {
+        let tz = FixedOffset::west_opt(12 * 3600).expect("UTC-12");
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("valid date");
+
+        let window = utc_window_for_date_in_timezone(date, &tz).expect("utc window");
+        assert_eq!(
+            window.start_utc,
+            chrono::Utc.with_ymd_and_hms(2026, 4, 11, 12, 0, 0).unwrap()
+        );
+        assert_eq!(
+            window.end_utc,
+            chrono::Utc.with_ymd_and_hms(2026, 4, 12, 12, 0, 0).unwrap()
+        );
+
+        let dates = utc_dates_for_local_date_in_timezone(date, &tz).expect("utc dates");
+        assert_eq!(
+            dates,
+            vec![
+                chrono::NaiveDate::from_ymd_opt(2026, 4, 11).expect("date"),
+                chrono::NaiveDate::from_ymd_opt(2026, 4, 12).expect("date"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_utc_window_duration_is_23_hours_on_dst_start_day() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 3, 8).expect("valid date");
+        let window = utc_window_for_date_in_timezone(date, &New_York).expect("utc window");
+        assert_eq!(window.end_utc - window.start_utc, Duration::hours(23));
+    }
+
+    #[test]
+    fn test_utc_window_duration_is_25_hours_on_dst_end_day() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 11, 1).expect("valid date");
+        let window = utc_window_for_date_in_timezone(date, &New_York).expect("utc window");
+        assert_eq!(window.end_utc - window.start_utc, Duration::hours(25));
     }
 }


### PR DESCRIPTION
## Summary
- release-sync changes from `dev` into `main`
- bump crate version from `0.13.7` to `0.13.8` to trigger a new release tag

## Notes
- this PR includes commits that are currently in `dev` but not yet in `main`
- release workflow on `main` resolves the tag from `Cargo.toml` (`v0.13.8`)

## Verification
- cargo build
- cargo clippy --all-targets --all-features
- cargo test
