### PR TITLE
chore: bump version to 0.13.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump crate version from 0.13.8 to 0.13.9 in Cargo.toml
- sync package version in Cargo.lock

## Verification
- cargo build
- cargo clippy
- cargo test