### PR TITLE
chore: harden release artifacts and log redaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # LLM_PROVIDER=anthropic
 
 # Anthropic Claude API 키
-ANTHROPIC_API_KEY=sk-ant-your-key-here
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # OpenAI API 키 (LLM_PROVIDER=openai 사용 시 필요)
-# OPENAI_API_KEY=sk-your-key-here
+# OPENAI_API_KEY=your_openai_api_key_here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Build release binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          export RUSTFLAGS="--remap-path-prefix=$GITHUB_WORKSPACE=/workspace --remap-path-prefix=$RUNNER_TEMP=/runner-temp --remap-path-prefix=$HOME=/home/runner"
+          cargo build --release --target ${{ matrix.target }}
+
+      - name: Build release binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:RUSTFLAGS = "--remap-path-prefix=$env:GITHUB_WORKSPACE=/workspace --remap-path-prefix=$env:USERPROFILE=/Users/runner"
+          cargo build --release --target ${{ matrix.target }}
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ indicatif = "0.18"
 
 [dev-dependencies]
 chrono-tz = "0.10"
+
+[profile.release]
+strip = "debuginfo"

--- a/docs/superpowers/plans/2026-03-20-i18n-english-first.md
+++ b/docs/superpowers/plans/2026-03-20-i18n-english-first.md
@@ -61,7 +61,7 @@
 - `docs/LEARNING_GUIDE.md`
 
 ### Create (Private, not in repo)
-- `~/.claude/projects/-Users-jinwoohan-workspace-repos-company-zerorder-rwd/CLAUDE.md` — Korean personal preferences
+- `~/.claude/projects/-Users-example-workspace-repos-company-example-rwd/CLAUDE.md` — Korean personal preferences
 
 ---
 
@@ -794,7 +794,7 @@ git commit -m "docs: translate all documentation to English"
 **Files:**
 - Rewrite: `CLAUDE.md` (repo root)
 - Modify: `Cargo.toml` (description)
-- Create: `~/.claude/projects/-Users-jinwoohan-workspace-repos-company-zerorder-rwd/CLAUDE.md` (private, Korean)
+- Create: `~/.claude/projects/-Users-example-workspace-repos-company-example-rwd/CLAUDE.md` (private, Korean)
 
 - [ ] **Step 1: Rewrite repo `CLAUDE.md` in English**
 
@@ -833,7 +833,7 @@ description = "CLI tool that analyzes AI coding session logs and extracts daily 
 
 - [ ] **Step 3: Create private Korean CLAUDE.md**
 
-Write to `~/.claude/projects/-Users-jinwoohan-workspace-repos-company-zerorder-rwd/CLAUDE.md`:
+Write to `~/.claude/projects/-Users-example-workspace-repos-company-example-rwd/CLAUDE.md`:
 
 ```markdown
 # Personal Preferences

--- a/docs/superpowers/plans/2026-04-11-multi-root-agent-session-discovery-next-session-prompt.md
+++ b/docs/superpowers/plans/2026-04-11-multi-root-agent-session-discovery-next-session-prompt.md
@@ -3,7 +3,7 @@
 다음 세션에서 아래 프롬프트를 그대로 사용한다.
 
 ```text
-/home/jinwoo/workspace/hobby/rwd 레포에서 아래 설계를 구현해줘.
+/home/example/workspace/hobby/rwd 레포에서 아래 설계를 구현해줘.
 
 먼저 이 문서를 읽어:
 - docs/superpowers/specs/2026-04-11-multi-root-agent-session-discovery-design.md

--- a/docs/superpowers/specs/2026-04-11-multi-root-agent-session-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-11-multi-root-agent-session-discovery-design.md
@@ -11,14 +11,14 @@
 
 ### 실제로 문제가 되는 시나리오
 
-1. WSL CLI로 작업한 Codex 세션은 `/home/jinwoo/.codex/sessions`에 쌓임
-2. Codex Desktop App 세션은 `/mnt/c/Users/qew85/.codex/sessions`에 쌓임
+1. WSL CLI로 작업한 Codex 세션은 `/home/example/.codex/sessions`에 쌓임
+2. Codex Desktop App 세션은 `/mnt/c/Users/example/.codex/sessions`에 쌓임
 3. 두 경로가 모두 존재하면 현재 구현은 `/home/...`만 읽고 `/mnt/...`는 무시함
 4. 결과적으로 `rwd today`가 오늘의 실제 작업 일부를 놓침
 
 Claude Code도 같은 문제가 생길 수 있다.
 
-1. WSL 안에서 Claude CLI를 사용하면 `/home/jinwoo/.claude/projects`
+1. WSL 안에서 Claude CLI를 사용하면 `/home/example/.claude/projects`
 2. Windows 쪽 Claude 환경을 WSL에서 읽으면 `/mnt/c/Users/.../.claude/projects`
 3. 두 경로가 동시에 존재할 수 있음
 
@@ -84,12 +84,12 @@ Claude 예시:
 ```toml
 [input]
 codex_roots = [
-  "/home/jinwoo/.codex/sessions",
-  "/mnt/c/Users/qew85/.codex/sessions",
+  "/home/example/.codex/sessions",
+  "/mnt/c/Users/example/.codex/sessions",
 ]
 claude_roots = [
-  "/home/jinwoo/.claude/projects",
-  "/mnt/c/Users/qew85/.claude/projects",
+  "/home/example/.claude/projects",
+  "/mnt/c/Users/example/.claude/projects",
 ]
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1573,21 +1573,21 @@ anthropic_api_key = "sk-test"
 path = "/tmp/vault"
 
 [input]
-codex_roots = ["/home/jinwoo/.codex/sessions", "/mnt/c/Users/jinwoo/.codex/sessions"]
-claude_roots = ["/home/jinwoo/.claude/projects"]
+codex_roots = ["/home/example/.codex/sessions", "/mnt/c/Users/example/.codex/sessions"]
+claude_roots = ["/home/example/.claude/projects"]
 "#;
         let config: Config = toml::from_str(toml_str).expect("parse");
         let input = config.input.expect("input section");
         assert_eq!(
             input.codex_roots,
             Some(vec![
-                "/home/jinwoo/.codex/sessions".to_string(),
-                "/mnt/c/Users/jinwoo/.codex/sessions".to_string()
+                "/home/example/.codex/sessions".to_string(),
+                "/mnt/c/Users/example/.codex/sessions".to_string()
             ])
         );
         assert_eq!(
             input.claude_roots,
-            Some(vec!["/home/jinwoo/.claude/projects".to_string()])
+            Some(vec!["/home/example/.claude/projects".to_string()])
         );
         assert!(input.claude.is_none());
     }
@@ -1603,7 +1603,7 @@ anthropic_api_key = "sk-test"
 path = "/tmp/vault"
 
 [input.claude]
-roots = ["/mnt/c/Users/jinwoo/.claude/projects"]
+roots = ["/mnt/c/Users/example/.claude/projects"]
 include_automated = true
 "#;
         let config: Config = toml::from_str(toml_str).expect("parse");
@@ -1611,7 +1611,7 @@ include_automated = true
         let claude = input.claude.expect("claude section");
         assert_eq!(
             claude.roots,
-            Some(vec!["/mnt/c/Users/jinwoo/.claude/projects".to_string()])
+            Some(vec!["/mnt/c/Users/example/.claude/projects".to_string()])
         );
         assert!(claude.include_automated);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,9 @@ async fn main() {
                     if let Some(parent) = log_path.parent() {
                         let _ = std::fs::create_dir_all(parent);
                     }
-                    let _ = std::fs::write(&log_path, format!("{e}"));
+                    let error_text = format!("{e}");
+                    let (redacted_error, _) = redactor::redact_text(&error_text);
+                    let _ = std::fs::write(&log_path, redacted_error);
                     send_notification(
                         crate::messages::background::NOTIFY_TITLE,
                         &crate::messages::background::notify_failure(&log_path.display()),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -183,6 +183,21 @@ pub mod auth {
 
 /// Error messages used across the application.
 pub mod error {
+    fn sanitize_api_error_body(body: &str) -> String {
+        let trimmed = body.trim();
+        if trimmed.is_empty() {
+            return "<empty body>".to_string();
+        }
+
+        let (redacted, _) = crate::redactor::redact_text(trimmed);
+        const MAX_BODY_CHARS: usize = 240;
+        let mut out: String = redacted.chars().take(MAX_BODY_CHARS).collect();
+        if redacted.chars().count() > MAX_BODY_CHARS {
+            out.push_str("...(truncated)");
+        }
+        out
+    }
+
     pub const NO_CONFIG: &str = "No config found. Run `rwd init` first.";
     pub const NO_CACHE: &str = "No cache found. Running today analysis first...";
     pub const NO_CACHE_AFTER_ANALYSIS: &str = "No cache found even after analysis.";
@@ -214,11 +229,13 @@ pub mod error {
     }
 
     pub fn api_request_failed(status: &dyn std::fmt::Display, body: &str) -> String {
-        format!("API request failed ({status}): {body}")
+        let safe_body = sanitize_api_error_body(body);
+        format!("API request failed ({status}): {safe_body}")
     }
 
     pub fn openai_api_request_failed(status: &dyn std::fmt::Display, body: &str) -> String {
-        format!("OpenAI API request failed ({status}): {body}")
+        let safe_body = sanitize_api_error_body(body);
+        format!("OpenAI API request failed ({status}): {safe_body}")
     }
 
     pub const API_NO_TEXT_BLOCK: &str = "No text block in API response";
@@ -600,5 +617,25 @@ pub mod verbose {
 
     pub fn markdown_file_size(path: &dyn std::fmt::Display, size_kb: f64) -> String {
         format!("Markdown size: {path} ({size_kb:.1} KB)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::error;
+
+    #[test]
+    fn test_api_request_failed_masks_sensitive_body() {
+        let body = r#"{"error":"invalid key sk-abcdefghijklmnopqrstuvwxyz1234"}"#;
+        let msg = error::api_request_failed(&401, body);
+        assert!(!msg.contains("sk-abcdefghijklmnopqrstuvwxyz1234"));
+        assert!(msg.contains("[REDACTED:API_KEY]"));
+    }
+
+    #[test]
+    fn test_api_request_failed_truncates_long_body() {
+        let long_body = "x".repeat(400);
+        let msg = error::openai_api_request_failed(&500, &long_body);
+        assert!(msg.contains("...(truncated)"));
     }
 }

--- a/src/parser/claude.rs
+++ b/src/parser/claude.rs
@@ -735,7 +735,7 @@ mod tests {
             )
             .expect("prompt automated"),
             serde_json::from_str::<LogEntry>(
-                r#"{"type":"progress","sessionId":"s4","timestamp":"2026-03-11T12:05:00Z","entrypoint":"cli","cwd":"/home/jinwoo/.claude/hooks/post-tool"}"#,
+                r#"{"type":"progress","sessionId":"s4","timestamp":"2026-03-11T12:05:00Z","entrypoint":"cli","cwd":"/home/example/.claude/hooks/post-tool"}"#,
             )
             .expect("cwd automated"),
             serde_json::from_str::<LogEntry>(

--- a/src/update.rs
+++ b/src/update.rs
@@ -18,8 +18,17 @@ fn is_newer(latest: &str, current: &str) -> bool {
 }
 
 fn is_local_dev_binary(current_exe: &Path) -> bool {
-    let manifest_target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
-    current_exe.starts_with(manifest_target)
+    // Avoid embedding build-machine absolute paths via `env!("CARGO_MANIFEST_DIR")`.
+    // A local cargo binary path usually includes `.../target/{debug|release}/...`.
+    let mut prev_was_target = false;
+    for component in current_exe.components() {
+        let name = component.as_os_str().to_string_lossy();
+        if prev_was_target && (name == "debug" || name == "release") {
+            return true;
+        }
+        prev_was_target = name == "target";
+    }
+    false
 }
 
 fn should_skip_update_notice(current_exe: &Path) -> bool {
@@ -537,11 +546,8 @@ mod tests {
 
     #[test]
     fn local_dev_binary_detects_manifest_target_path() {
-        let current = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("target")
-            .join("debug")
-            .join("rwd");
-        assert!(super::is_local_dev_binary(&current));
+        let current = std::path::Path::new("/tmp/example/target/debug/rwd");
+        assert!(super::is_local_dev_binary(current));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- avoid embedding workspace path via manifest-dir based local-dev detection\n- redact + truncate API error bodies before surfacing/logging\n- redact worker failure logs before writing to ~/.rwd/worker.log\n- add release hardening: remap-path-prefix in CI and strip debuginfo\n- replace personal/local path literals in source/docs with generic placeholders\n\n## Validation\n- cargo build\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test