### PR TITLE
chore: release v0.13.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.9"
+version = "0.13.10"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.9"
+version = "0.13.10"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump package version to 0.13.10 for release
- sync Cargo.lock root package version

## Verification
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test