### PR TITLE
feat: unify session analysis pipeline across providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,12 +553,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -566,6 +582,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -587,6 +614,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,8 +642,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1521,6 +1570,7 @@ dependencies = [
  "console 0.15.11",
  "dialoguer",
  "dirs",
+ "futures",
  "indicatif",
  "notify-rust",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ regex = "1"
 notify-rust = "4"
 semver = "1.0.27"
 indicatif = "0.18"
+futures = "0.3"
 
 [dev-dependencies]
 chrono-tz = "0.10"

--- a/src/analyzer/codex_exec.rs
+++ b/src/analyzer/codex_exec.rs
@@ -26,7 +26,8 @@ pub async fn call_codex_json_api(
         max_tokens,
         model,
         reasoning_effort,
-    );
+    )
+    .await;
     let _ = std::fs::remove_file(schema_path);
     result
 }
@@ -40,7 +41,7 @@ pub async fn call_codex_text_api(
     reasoning_effort: &str,
 ) -> Result<(String, ApiUsage), AnalyzerError> {
     let prompt = compose_prompt(system_prompt, conversation_text);
-    run_codex_exec(&prompt, None, max_tokens, model, reasoning_effort)
+    run_codex_exec(&prompt, None, max_tokens, model, reasoning_effort).await
 }
 
 fn compose_prompt(system_prompt: &str, conversation_text: &str) -> String {
@@ -118,7 +119,34 @@ const ANALYSIS_OUTPUT_SCHEMA: &str = r#"{
   }
 }"#;
 
-fn run_codex_exec(
+async fn run_codex_exec(
+    prompt: &str,
+    schema_path: Option<&Path>,
+    max_tokens: u32,
+    model: &str,
+    reasoning_effort: &str,
+) -> Result<(String, ApiUsage), AnalyzerError> {
+    let prompt = prompt.to_string();
+    let schema_path = schema_path.map(|path| path.to_path_buf());
+    let model = model.to_string();
+    let reasoning_effort = reasoning_effort.to_string();
+
+    tokio::task::spawn_blocking(move || {
+        run_codex_exec_blocking(
+            &prompt,
+            schema_path.as_deref(),
+            max_tokens,
+            &model,
+            &reasoning_effort,
+        )
+        .map_err(|err| err.to_string())
+    })
+    .await
+    .map_err(|join_err| format!("Codex exec join error: {join_err}"))?
+    .map_err(Into::into)
+}
+
+fn run_codex_exec_blocking(
     prompt: &str,
     schema_path: Option<&Path>,
     max_tokens: u32,

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -25,7 +25,65 @@ pub struct ApiUsage {
 use crate::parser::claude::LogEntry;
 use crate::parser::codex::CodexEntry;
 use crate::redactor::RedactResult;
-use planner::{ExecutionPlan, StepStrategy};
+use futures::stream::{FuturesUnordered, StreamExt};
+use planner::{ExecutionPlan, SessionEstimate, StepStrategy};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Source tag for a unified analysis task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionSource {
+    Claude,
+    Codex,
+}
+
+/// Common per-session analysis input used by both Claude and Codex flows.
+#[derive(Debug, Clone)]
+pub struct SessionTask {
+    pub source: SessionSource,
+    pub session_id: String,
+    pub prompt_text: String,
+    pub messages: Vec<(String, String)>,
+    pub estimated_tokens: u64,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedSessionTask {
+    index: usize,
+    step_number: usize,
+    total_steps: usize,
+    task: SessionTask,
+    strategy: StepStrategy,
+    estimated_tokens: u64,
+}
+
+struct PlannedSessionOutcome {
+    index: usize,
+    step_number: usize,
+    total_steps: usize,
+    session_id: String,
+    elapsed_secs: f64,
+    usage: ApiUsage,
+    analysis: AnalysisResult,
+    redact: RedactResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryAction {
+    None,
+    RateLimit429,
+    JsonParse,
+}
+
+fn classify_retry_action(err_msg: &str) -> RetryAction {
+    if err_msg.contains("429") {
+        RetryAction::RateLimit429
+    } else if err_msg.contains(crate::messages::error::JSON_PARSE_FAILED_MARKER) {
+        RetryAction::JsonParse
+    } else {
+        RetryAction::None
+    }
+}
 
 /// Starts a terminal spinner on stderr.
 fn start_spinner(msg: String) -> indicatif::ProgressBar {
@@ -59,13 +117,105 @@ async fn countdown_sleep(total_secs: u64) {
     stop_spinner(spinner);
 }
 
-/// Main entry point: probes rate limits, plans execution, and runs LLM analysis.
+/// Extracts session_id from a LogEntry (None for FileHistorySnapshot and Other).
+fn entry_session_id(entry: &LogEntry) -> Option<&str> {
+    match entry {
+        LogEntry::User(e) => Some(&e.session_id),
+        LogEntry::Assistant(e) => Some(&e.session_id),
+        LogEntry::Progress(e) => Some(&e.session_id),
+        LogEntry::System(e) => e.session_id.as_deref(),
+        LogEntry::FileHistorySnapshot(_) | LogEntry::Other(_) => None,
+    }
+}
+
+/// Builds common session tasks from Claude entries.
+pub fn build_claude_session_tasks(entries: &[LogEntry]) -> Result<Vec<SessionTask>, AnalyzerError> {
+    let session_ids = prompt::extract_session_ids(entries);
+    if session_ids.is_empty() {
+        return Err(crate::messages::error::NO_CONVERSATION_CLAUDE.into());
+    }
+
+    let estimated_by_session: HashMap<String, u64> = prompt::estimate_sessions(entries)
+        .into_iter()
+        .map(|estimate| (estimate.session_id, estimate.estimated_tokens))
+        .collect();
+
+    let mut tasks = Vec::new();
+    for session_id in session_ids {
+        let session_entries: Vec<LogEntry> = entries
+            .iter()
+            .filter(|entry| entry_session_id(entry) == Some(session_id.as_str()))
+            .cloned()
+            .collect();
+
+        let prompt_text = prompt::build_prompt(&session_entries)?;
+        let messages = prompt::extract_messages(&session_entries);
+        let estimated_tokens = estimated_by_session
+            .get(&session_id)
+            .copied()
+            .unwrap_or_else(|| prompt::estimate_prompt_tokens(&prompt_text));
+
+        tasks.push(SessionTask {
+            source: SessionSource::Claude,
+            session_id,
+            prompt_text,
+            messages,
+            estimated_tokens,
+        });
+    }
+
+    Ok(tasks)
+}
+
+/// Builds one common session task from Codex entries.
+pub fn build_codex_session_task(
+    entries: &[CodexEntry],
+    session_id: &str,
+) -> Result<SessionTask, AnalyzerError> {
+    let prompt_text = prompt::build_codex_prompt(entries, session_id)?;
+    let messages = prompt::extract_codex_messages(entries);
+    let estimated_tokens = prompt::estimate_prompt_tokens(&prompt_text);
+
+    Ok(SessionTask {
+        source: SessionSource::Codex,
+        session_id: session_id.to_string(),
+        prompt_text,
+        messages,
+        estimated_tokens,
+    })
+}
+
+/// Main entry point for Claude log analysis.
 pub async fn analyze_entries(
     entries: &[LogEntry],
     redactor_enabled: bool,
     verbose: bool,
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult), AnalyzerError> {
+    let tasks = build_claude_session_tasks(entries)?;
+    analyze_session_tasks(tasks, redactor_enabled, verbose, lang).await
+}
+
+/// Shared session analysis pipeline used by both Claude and Codex inputs.
+pub async fn analyze_session_tasks(
+    tasks: Vec<SessionTask>,
+    redactor_enabled: bool,
+    verbose: bool,
+    lang: &crate::config::Lang,
+) -> Result<(AnalysisResult, RedactResult), AnalyzerError> {
+    if tasks.is_empty() {
+        return Err(crate::messages::error::NO_SESSIONS.into());
+    }
+
+    if verbose {
+        let claude_tasks = tasks
+            .iter()
+            .filter(|task| task.source == SessionSource::Claude)
+            .count();
+        let codex_tasks = tasks.len().saturating_sub(claude_tasks);
+        eprintln!("• Session tasks: Claude {claude_tasks}, Codex {codex_tasks}");
+    }
+
     let (provider, api_key) = provider::load_provider()?;
 
     // 1. Probe actual rate limits
@@ -102,129 +252,57 @@ pub async fn analyze_entries(
         );
     }
 
-    // 2. Estimate tokens per session
-    let estimates = prompt::estimate_sessions(entries);
-
-    // 3. Build execution plan
+    // 2. Build execution plan from unified tasks
+    let estimates: Vec<SessionEstimate> = tasks
+        .iter()
+        .map(|task| SessionEstimate {
+            session_id: task.session_id.clone(),
+            estimated_tokens: task.estimated_tokens,
+        })
+        .collect();
     let plan = planner::build_execution_plan(&limits, &estimates, provider.max_output_tokens());
 
-    // 4. Display plan
-    if plan.is_single_shot {
-        eprintln!(
-            "{}",
-            crate::messages::status::plan_single_shot(plan.total_estimated_tokens)
-        );
-    } else {
-        eprintln!(
-            "{}",
-            crate::messages::status::plan_multi_step(plan.steps.len(), plan.total_estimated_tokens)
-        );
-        if verbose {
-            for step in &plan.steps {
-                match &step.strategy {
-                    StepStrategy::Direct => {
-                        eprintln!(
-                            "{}",
-                            crate::messages::status::plan_step_direct(
-                                &step.session_id,
-                                step.estimated_tokens,
-                            )
-                        );
-                    }
-                    StepStrategy::Summarize { chunks } => {
-                        eprintln!(
-                            "{}",
-                            crate::messages::status::plan_step_summarize(
-                                &step.session_id,
-                                step.estimated_tokens,
-                                *chunks,
-                            )
-                        );
-                    }
-                };
+    // 3. Display plan
+    eprintln!(
+        "{}",
+        crate::messages::status::plan_multi_step(plan.steps.len(), plan.total_estimated_tokens)
+    );
+    if verbose {
+        for step in &plan.steps {
+            match &step.strategy {
+                StepStrategy::Direct => {
+                    eprintln!(
+                        "{}",
+                        crate::messages::status::plan_step_direct(
+                            &step.session_id,
+                            step.estimated_tokens,
+                        )
+                    );
+                }
+                StepStrategy::Summarize { chunks } => {
+                    eprintln!(
+                        "{}",
+                        crate::messages::status::plan_step_summarize(
+                            &step.session_id,
+                            step.estimated_tokens,
+                            *chunks,
+                        )
+                    );
+                }
             }
         }
     }
 
-    // 5. Execute analysis
-    if plan.is_single_shot {
-        let sp = start_spinner(crate::messages::status::ANALYZING_INSIGHT.into());
-        let started = std::time::Instant::now();
-        let prompt_text = prompt::build_prompt(entries)?;
-        let (final_prompt, redact_result) = if redactor_enabled {
-            crate::redactor::redact_text(&prompt_text)
-        } else {
-            (prompt_text.clone(), RedactResult::empty())
-        };
-        let (raw_response, usage) = provider
-            .call_api(
-                &api_key,
-                &final_prompt,
-                plan.recommended_max_tokens as u32,
-                lang,
-            )
-            .await?;
-        let elapsed = started.elapsed();
-        stop_spinner(sp);
-        if verbose {
-            eprintln!(
-                "{}",
-                crate::messages::verbose::api_done_single(
-                    elapsed.as_secs_f64(),
-                    usage.input_tokens,
-                    usage.output_tokens
-                )
-            );
-        }
-        let result = match insight::parse_response(&raw_response) {
-            Ok(result) => result,
-            Err(parse_err)
-                if parse_err
-                    .to_string()
-                    .contains(crate::messages::error::JSON_PARSE_FAILED_MARKER) =>
-            {
-                let hinted = format!("{JSON_RETRY_PREFIX}{prompt_text}");
-                let retry_prompt = if redactor_enabled {
-                    crate::redactor::redact_text(&hinted).0
-                } else {
-                    hinted
-                };
-                let (retry_raw_response, _retry_usage) = provider
-                    .call_api(
-                        &api_key,
-                        &retry_prompt,
-                        plan.recommended_max_tokens as u32,
-                        lang,
-                    )
-                    .await?;
-                insight::parse_response(&retry_raw_response)?
-            }
-            Err(parse_err) => return Err(parse_err),
-        };
-        Ok((result, redact_result))
-    } else {
-        execute_plan(
-            &plan,
-            entries,
-            &provider,
-            &api_key,
-            redactor_enabled,
-            verbose,
-            lang,
-        )
-        .await
-    }
-}
-
-/// Extracts session_id from a LogEntry (None for FileHistorySnapshot and Other).
-fn entry_session_id(entry: &LogEntry) -> Option<&str> {
-    match entry {
-        LogEntry::User(e) => Some(&e.session_id),
-        LogEntry::Assistant(e) => Some(&e.session_id),
-        LogEntry::Progress(e) => Some(&e.session_id),
-        LogEntry::System(e) => e.session_id.as_deref(),
-        LogEntry::FileHistorySnapshot(_) | LogEntry::Other(_) => None,
-    }
+    execute_plan_parallel(
+        &plan,
+        tasks,
+        &provider,
+        &api_key,
+        redactor_enabled,
+        verbose,
+        lang,
+    )
+    .await
 }
 
 /// Generates a development progress summary from concatenated session work_summaries.
@@ -251,270 +329,322 @@ pub async fn analyze_slack(
     Ok(raw_response)
 }
 
-/// Analyzes Codex session entries. Same pipeline as Claude but uses Codex-specific prompts.
-pub async fn analyze_codex_entries(
-    entries: &[CodexEntry],
-    session_id: &str,
-    redactor_enabled: bool,
-    lang: &crate::config::Lang,
-) -> Result<(AnalysisResult, RedactResult), AnalyzerError> {
-    let (provider, api_key) = provider::load_provider()?;
-    let prompt_text = prompt::build_codex_prompt(entries, session_id)?;
-    let (final_prompt, redact_result) = if redactor_enabled {
-        crate::redactor::redact_text(&prompt_text)
-    } else {
-        (prompt_text, RedactResult::empty())
+/// Computes dynamic concurrency for session execution.
+fn dynamic_parallelism(
+    provider: &provider::LlmProvider,
+    limits: &planner::RateLimits,
+    max_estimated_tokens: u64,
+    session_count: usize,
+) -> usize {
+    if session_count == 0 {
+        return 0;
+    }
+
+    let provider_cap = match provider {
+        provider::LlmProvider::Codex { .. } => 2,
+        _ => 4,
     };
-    let (raw_response, _usage) = provider
-        .call_api(&api_key, &final_prompt, 1_950, lang)
-        .await?;
-    let result = insight::parse_response(&raw_response)?;
-    Ok((result, redact_result))
+
+    let rate_cap = match limits.requests_per_minute {
+        0..=19 => 1,
+        20..=39 => 2,
+        40..=79 => 3,
+        _ => 4,
+    };
+
+    let token_cap = if limits.input_tokens_per_minute == 0
+        || (max_estimated_tokens as f64) >= (limits.input_tokens_per_minute as f64 * 0.6)
+    {
+        1
+    } else {
+        provider_cap
+    };
+
+    session_count
+        .min(provider_cap)
+        .min(rate_cap)
+        .min(token_cap)
+        .max(1)
 }
 
-/// Executes the plan sequentially and merges results.
-async fn execute_plan(
+/// Executes the plan in parallel and merges results in plan order.
+async fn execute_plan_parallel(
     plan: &ExecutionPlan,
-    entries: &[LogEntry],
+    tasks: Vec<SessionTask>,
     provider: &provider::LlmProvider,
     api_key: &str,
     redactor_enabled: bool,
     verbose: bool,
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult), AnalyzerError> {
+    if plan.steps.is_empty() {
+        return Err(crate::messages::error::NO_SESSIONS.into());
+    }
+
+    let mut task_by_session: HashMap<String, SessionTask> = HashMap::new();
+    for task in tasks {
+        task_by_session.insert(task.session_id.clone(), task);
+    }
+
+    let total_steps = plan.steps.len();
+    let mut planned_tasks = Vec::new();
+    for (index, step) in plan.steps.iter().enumerate() {
+        let task = task_by_session
+            .get(&step.session_id)
+            .cloned()
+            .ok_or_else(|| format!("Missing task for session {}", step.session_id))?;
+        planned_tasks.push(PlannedSessionTask {
+            index,
+            step_number: index + 1,
+            total_steps,
+            task,
+            strategy: step.strategy.clone(),
+            estimated_tokens: step.estimated_tokens,
+        });
+    }
+
+    let max_estimated = planned_tasks
+        .iter()
+        .map(|task| task.estimated_tokens)
+        .max()
+        .unwrap_or(0);
+    let parallelism = dynamic_parallelism(provider, &plan.rate_limits, max_estimated, total_steps);
+
+    if verbose {
+        eprintln!("• Parallel session workers: {parallelism}");
+    }
+
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(parallelism));
+    let rate_limits = Arc::new(plan.rate_limits.clone());
+    let mut inflight = FuturesUnordered::new();
+
+    for planned in planned_tasks {
+        eprintln!(
+            "{}",
+            crate::messages::status::step_analyzing(
+                planned.step_number,
+                planned.total_steps,
+                &planned.task.session_id,
+            )
+        );
+
+        let semaphore = Arc::clone(&semaphore);
+        let limits = Arc::clone(&rate_limits);
+
+        inflight.push(async move {
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .map_err(|e| format!("Failed to acquire semaphore permit: {e}"))?;
+            run_planned_task(planned, provider, api_key, &limits, redactor_enabled, lang).await
+        });
+    }
+
+    let ordered = collect_ordered_outcomes(&mut inflight, total_steps, verbose).await?;
+    let (results, total_redact) = merge_ordered_outcomes(ordered)?;
+    Ok((insight::merge_results(results), total_redact))
+}
+
+async fn collect_ordered_outcomes<S>(
+    inflight: &mut S,
+    total_steps: usize,
+    verbose: bool,
+) -> Result<Vec<Option<PlannedSessionOutcome>>, AnalyzerError>
+where
+    S: futures::stream::Stream<Item = Result<PlannedSessionOutcome, AnalyzerError>> + Unpin,
+{
+    let mut ordered: Vec<Option<PlannedSessionOutcome>> =
+        std::iter::repeat_with(|| None).take(total_steps).collect();
+
+    while let Some(outcome_result) = inflight.next().await {
+        let outcome = outcome_result?;
+
+        if verbose {
+            eprintln!(
+                "{}",
+                crate::messages::verbose::step_done_detail(
+                    outcome.step_number,
+                    outcome.total_steps,
+                    &outcome.session_id,
+                    outcome.elapsed_secs,
+                    outcome.usage.input_tokens,
+                    outcome.usage.output_tokens,
+                )
+            );
+        } else {
+            eprintln!(
+                "{}",
+                crate::messages::status::step_done(outcome.step_number, outcome.total_steps)
+            );
+        }
+
+        let outcome_index = outcome.index;
+        ordered[outcome_index] = Some(outcome);
+    }
+
+    Ok(ordered)
+}
+
+fn merge_ordered_outcomes(
+    ordered: Vec<Option<PlannedSessionOutcome>>,
+) -> Result<(Vec<AnalysisResult>, RedactResult), AnalyzerError> {
     let mut results = Vec::new();
     let mut total_redact = RedactResult::empty();
-    let total_steps = plan.steps.len();
 
-    for (i, step) in plan.steps.iter().enumerate() {
-        let session_entries: Vec<LogEntry> = entries
-            .iter()
-            .filter(|e| entry_session_id(e) == Some(step.session_id.as_str()))
-            .cloned()
-            .collect();
-
-        // Direct steps use an outer spinner; Summarize steps have their own inner spinner.
-        let use_spinner = step.strategy == StepStrategy::Direct;
-        let step_start = std::time::Instant::now();
-        let sp = if use_spinner {
-            Some(start_spinner(crate::messages::status::step_analyzing(
-                i + 1,
-                total_steps,
-                &step.session_id,
-            )))
-        } else {
-            None
-        };
-
-        let result = match &step.strategy {
-            StepStrategy::Direct => {
-                execute_direct_step(&session_entries, provider, api_key, redactor_enabled, lang)
-                    .await
-            }
-            StepStrategy::Summarize { .. } => {
-                execute_summarize_step(
-                    &session_entries,
-                    &step.session_id,
-                    provider,
-                    api_key,
-                    &plan.rate_limits,
-                    redactor_enabled,
-                    lang,
-                )
-                .await
-            }
-        };
-
-        match result {
-            Ok((analysis, redact, usage)) => {
-                if let Some(h) = sp {
-                    stop_spinner(h);
-                }
-                let elapsed = step_start.elapsed();
-                if verbose {
-                    eprintln!(
-                        "{}",
-                        crate::messages::verbose::step_done_detail(
-                            i + 1,
-                            total_steps,
-                            &step.session_id,
-                            elapsed.as_secs_f64(),
-                            usage.input_tokens,
-                            usage.output_tokens,
-                        )
-                    );
-                } else {
-                    eprintln!("{}", crate::messages::status::step_done(i + 1, total_steps));
-                }
-                results.push(analysis);
-                total_redact.merge(redact);
-            }
-            Err(e) => {
-                if let Some(h) = sp {
-                    stop_spinner(h);
-                }
-                let err_msg = e.to_string();
-                if err_msg.contains("429") {
-                    // 429 rate limit: wait 60s then retry
-                    countdown_sleep(60).await;
-
-                    let retry_sp = if use_spinner {
-                        Some(start_spinner(crate::messages::status::step_retrying(
-                            i + 1,
-                            total_steps,
-                            &step.session_id,
-                        )))
-                    } else {
-                        None
-                    };
-
-                    let retry = match &step.strategy {
-                        StepStrategy::Direct => {
-                            execute_direct_step(
-                                &session_entries,
-                                provider,
-                                api_key,
-                                redactor_enabled,
-                                lang,
-                            )
-                            .await
-                        }
-                        StepStrategy::Summarize { .. } => {
-                            execute_summarize_step(
-                                &session_entries,
-                                &step.session_id,
-                                provider,
-                                api_key,
-                                &plan.rate_limits,
-                                redactor_enabled,
-                                lang,
-                            )
-                            .await
-                        }
-                    };
-
-                    match retry {
-                        Ok((analysis, redact, _usage)) => {
-                            if let Some(h) = retry_sp {
-                                stop_spinner(h);
-                            }
-                            eprintln!(
-                                "{}",
-                                crate::messages::status::step_retry_success(i + 1, total_steps)
-                            );
-                            results.push(analysis);
-                            total_redact.merge(redact);
-                        }
-                        Err(retry_err) => {
-                            if let Some(h) = retry_sp {
-                                stop_spinner(h);
-                            }
-                            eprintln!(
-                                "{}",
-                                crate::messages::status::step_skip_retry(
-                                    i + 1,
-                                    total_steps,
-                                    &step.session_id,
-                                    &retry_err
-                                )
-                            );
-                        }
-                    }
-                } else if err_msg.contains(crate::messages::error::JSON_PARSE_FAILED_MARKER) {
-                    // JSON parse failure: retry with a stronger JSON-only instruction
-                    let retry_sp = if use_spinner {
-                        Some(start_spinner(crate::messages::status::step_reanalyzing(
-                            i + 1,
-                            total_steps,
-                            &step.session_id,
-                        )))
-                    } else {
-                        None
-                    };
-
-                    let retry = match &step.strategy {
-                        StepStrategy::Direct => {
-                            execute_direct_step_with_json_hint(
-                                &session_entries,
-                                provider,
-                                api_key,
-                                redactor_enabled,
-                                lang,
-                            )
-                            .await
-                        }
-                        StepStrategy::Summarize { .. } => {
-                            execute_summarize_step_with_json_hint(
-                                &session_entries,
-                                &step.session_id,
-                                provider,
-                                api_key,
-                                &plan.rate_limits,
-                                redactor_enabled,
-                                lang,
-                            )
-                            .await
-                        }
-                    };
-
-                    match retry {
-                        Ok((analysis, redact, _usage)) => {
-                            if let Some(h) = retry_sp {
-                                stop_spinner(h);
-                            }
-                            eprintln!(
-                                "{}",
-                                crate::messages::status::step_reanalysis_success(
-                                    i + 1,
-                                    total_steps
-                                )
-                            );
-                            results.push(analysis);
-                            total_redact.merge(redact);
-                        }
-                        Err(retry_err) => {
-                            if let Some(h) = retry_sp {
-                                stop_spinner(h);
-                            }
-                            eprintln!(
-                                "{}",
-                                crate::messages::status::step_skip_reanalysis(
-                                    i + 1,
-                                    total_steps,
-                                    &step.session_id,
-                                    &retry_err
-                                )
-                            );
-                        }
-                    }
-                } else {
-                    eprintln!(
-                        "{}",
-                        crate::messages::status::step_skip(
-                            i + 1,
-                            total_steps,
-                            &step.session_id,
-                            &err_msg
-                        )
-                    );
-                }
-            }
-        }
-
-        // Rate pacing: wait between steps (skip after the last one).
-        if i + 1 < total_steps {
-            let wait = summarizer::calculate_wait(step.estimated_tokens, &plan.rate_limits);
-            if wait > 0.0 {
-                countdown_sleep(wait.ceil() as u64).await;
-            }
-        }
+    for maybe in ordered {
+        let outcome = maybe.ok_or(crate::messages::error::ALL_SESSIONS_FAILED)?;
+        results.push(outcome.analysis);
+        total_redact.merge(outcome.redact);
     }
 
     if results.is_empty() {
         return Err(crate::messages::error::ALL_SESSIONS_FAILED.into());
     }
 
-    Ok((insight::merge_results(results), total_redact))
+    Ok((results, total_redact))
+}
+
+async fn run_planned_task(
+    planned: PlannedSessionTask,
+    provider: &provider::LlmProvider,
+    api_key: &str,
+    limits: &planner::RateLimits,
+    redactor_enabled: bool,
+    lang: &crate::config::Lang,
+) -> Result<PlannedSessionOutcome, AnalyzerError> {
+    let started = std::time::Instant::now();
+
+    let initial = execute_task(&planned, provider, api_key, limits, redactor_enabled, lang).await;
+
+    let (analysis, redact, usage) = match initial {
+        Ok(result) => result,
+        Err(e) => match classify_retry_action(&e.to_string()) {
+            RetryAction::RateLimit429 => {
+                countdown_sleep(60).await;
+                eprintln!(
+                    "{}",
+                    crate::messages::status::step_retrying(
+                        planned.step_number,
+                        planned.total_steps,
+                        &planned.task.session_id,
+                    )
+                );
+                execute_task(&planned, provider, api_key, limits, redactor_enabled, lang)
+                    .await
+                    .map_err(|retry_err| {
+                        format!(
+                            "Session {} failed after 429 retry: {}",
+                            planned.task.session_id, retry_err
+                        )
+                    })?
+            }
+            RetryAction::JsonParse => {
+                eprintln!(
+                    "{}",
+                    crate::messages::status::step_reanalyzing(
+                        planned.step_number,
+                        planned.total_steps,
+                        &planned.task.session_id,
+                    )
+                );
+                execute_task_with_json_hint(
+                    &planned,
+                    provider,
+                    api_key,
+                    limits,
+                    redactor_enabled,
+                    lang,
+                )
+                .await
+                .map_err(|retry_err| {
+                    format!(
+                        "Session {} failed after JSON retry: {}",
+                        planned.task.session_id, retry_err
+                    )
+                })?
+            }
+            RetryAction::None => return Err(e),
+        },
+    };
+
+    Ok(PlannedSessionOutcome {
+        index: planned.index,
+        step_number: planned.step_number,
+        total_steps: planned.total_steps,
+        session_id: planned.task.session_id,
+        elapsed_secs: started.elapsed().as_secs_f64(),
+        usage,
+        analysis,
+        redact,
+    })
+}
+
+async fn execute_task(
+    planned: &PlannedSessionTask,
+    provider: &provider::LlmProvider,
+    api_key: &str,
+    limits: &planner::RateLimits,
+    redactor_enabled: bool,
+    lang: &crate::config::Lang,
+) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
+    match planned.strategy {
+        StepStrategy::Direct => {
+            execute_direct_step(
+                &planned.task.prompt_text,
+                provider,
+                api_key,
+                redactor_enabled,
+                lang,
+            )
+            .await
+        }
+        StepStrategy::Summarize { .. } => {
+            execute_summarize_step(
+                &planned.task.messages,
+                &planned.task.session_id,
+                provider,
+                api_key,
+                limits,
+                redactor_enabled,
+                lang,
+            )
+            .await
+        }
+    }
+}
+
+async fn execute_task_with_json_hint(
+    planned: &PlannedSessionTask,
+    provider: &provider::LlmProvider,
+    api_key: &str,
+    limits: &planner::RateLimits,
+    redactor_enabled: bool,
+    lang: &crate::config::Lang,
+) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
+    match planned.strategy {
+        StepStrategy::Direct => {
+            execute_direct_step_with_json_hint(
+                &planned.task.prompt_text,
+                provider,
+                api_key,
+                redactor_enabled,
+                lang,
+            )
+            .await
+        }
+        StepStrategy::Summarize { .. } => {
+            execute_summarize_step_with_json_hint(
+                &planned.task.messages,
+                &planned.task.session_id,
+                provider,
+                api_key,
+                limits,
+                redactor_enabled,
+                lang,
+            )
+            .await
+        }
+    }
 }
 
 /// Instruction prepended to the conversation on JSON-parse retry.
@@ -527,17 +657,16 @@ No markdown, no explanation, no code blocks.\n\n";
 
 /// Direct step: sends the session prompt as-is.
 async fn execute_direct_step(
-    entries: &[LogEntry],
+    prompt_text: &str,
     provider: &provider::LlmProvider,
     api_key: &str,
     redactor_enabled: bool,
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
-    let prompt_text = prompt::build_prompt(entries)?;
     let (final_prompt, redact_result) = if redactor_enabled {
-        crate::redactor::redact_text(&prompt_text)
+        crate::redactor::redact_text(prompt_text)
     } else {
-        (prompt_text, RedactResult::empty())
+        (prompt_text.to_string(), RedactResult::empty())
     };
     let (raw_response, usage) = provider
         .call_api(api_key, &final_prompt, 4_096, lang)
@@ -548,13 +677,12 @@ async fn execute_direct_step(
 
 /// Direct step variant for JSON-parse retry: prepends a stronger instruction.
 async fn execute_direct_step_with_json_hint(
-    entries: &[LogEntry],
+    prompt_text: &str,
     provider: &provider::LlmProvider,
     api_key: &str,
     redactor_enabled: bool,
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
-    let prompt_text = prompt::build_prompt(entries)?;
     let hinted = format!("{JSON_RETRY_PREFIX}{prompt_text}");
     let (final_prompt, redact_result) = if redactor_enabled {
         crate::redactor::redact_text(&hinted)
@@ -570,7 +698,7 @@ async fn execute_direct_step_with_json_hint(
 
 /// Summarize step: splits a large session into chunks, summarizes, then analyzes.
 async fn execute_summarize_step(
-    entries: &[LogEntry],
+    messages: &[(String, String)],
     session_id: &str,
     provider: &provider::LlmProvider,
     api_key: &str,
@@ -578,8 +706,11 @@ async fn execute_summarize_step(
     redactor_enabled: bool,
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
-    let messages = prompt::extract_messages(entries);
-    let chunks = summarizer::split_into_chunks(&messages, limits.input_tokens_per_minute);
+    if messages.is_empty() {
+        return Err(format!("No conversation messages in session {session_id}").into());
+    }
+
+    let chunks = summarizer::split_into_chunks(messages, limits.input_tokens_per_minute.max(1));
     let summary_text =
         summarizer::summarize_chunks(&chunks, provider, api_key, limits, lang).await?;
 
@@ -598,7 +729,7 @@ async fn execute_summarize_step(
 
 /// Summarize step variant for JSON-parse retry: prepends a stronger instruction.
 async fn execute_summarize_step_with_json_hint(
-    entries: &[LogEntry],
+    messages: &[(String, String)],
     session_id: &str,
     provider: &provider::LlmProvider,
     api_key: &str,
@@ -606,8 +737,11 @@ async fn execute_summarize_step_with_json_hint(
     redactor_enabled: bool,
     lang: &crate::config::Lang,
 ) -> Result<(AnalysisResult, RedactResult, ApiUsage), AnalyzerError> {
-    let messages = prompt::extract_messages(entries);
-    let chunks = summarizer::split_into_chunks(&messages, limits.input_tokens_per_minute);
+    if messages.is_empty() {
+        return Err(format!("No conversation messages in session {session_id}").into());
+    }
+
+    let chunks = summarizer::split_into_chunks(messages, limits.input_tokens_per_minute.max(1));
     let summary_text =
         summarizer::summarize_chunks(&chunks, provider, api_key, limits, lang).await?;
 
@@ -622,4 +756,139 @@ async fn execute_summarize_step_with_json_hint(
         .await?;
     let result = insight::parse_response(&raw_response)?;
     Ok((result, redact_result, usage))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    fn sample_limits(rpm: u64, itpm: u64) -> planner::RateLimits {
+        planner::RateLimits {
+            input_tokens_per_minute: itpm,
+            output_tokens_per_minute: itpm / 4,
+            requests_per_minute: rpm,
+        }
+    }
+
+    fn sample_analysis(session_id: &str) -> AnalysisResult {
+        AnalysisResult {
+            sessions: vec![insight::SessionInsight {
+                session_id: session_id.to_string(),
+                work_summary: format!("summary-{session_id}"),
+                decisions: vec![],
+                curiosities: vec![],
+                corrections: vec![],
+                til: vec![],
+            }],
+        }
+    }
+
+    fn sample_outcome(index: usize, session_id: &str) -> PlannedSessionOutcome {
+        PlannedSessionOutcome {
+            index,
+            step_number: index + 1,
+            total_steps: 2,
+            session_id: session_id.to_string(),
+            elapsed_secs: 0.1,
+            usage: ApiUsage::default(),
+            analysis: sample_analysis(session_id),
+            redact: RedactResult::empty(),
+        }
+    }
+
+    #[test]
+    fn test_dynamic_parallelism_codex_is_capped_to_two() {
+        let provider = provider::LlmProvider::Codex {
+            model: "gpt-5.4".to_string(),
+            reasoning_effort: "xhigh".to_string(),
+        };
+        let p = dynamic_parallelism(&provider, &sample_limits(1_000, 1_000_000), 10_000, 10);
+        assert_eq!(p, 2);
+    }
+
+    #[test]
+    fn test_dynamic_parallelism_rate_cap_applies_for_api() {
+        let provider = provider::LlmProvider::OpenAi;
+        let p = dynamic_parallelism(&provider, &sample_limits(30, 1_000_000), 10_000, 10);
+        assert_eq!(p, 2);
+    }
+
+    #[test]
+    fn test_dynamic_parallelism_token_cap_for_large_sessions() {
+        let provider = provider::LlmProvider::Anthropic;
+        let p = dynamic_parallelism(&provider, &sample_limits(1_000, 30_000), 20_000, 10);
+        assert_eq!(p, 1);
+    }
+
+    #[test]
+    fn test_classify_retry_action_rate_limit_has_priority() {
+        let err = format!(
+            "429 and {}",
+            crate::messages::error::JSON_PARSE_FAILED_MARKER
+        );
+        assert_eq!(classify_retry_action(&err), RetryAction::RateLimit429);
+    }
+
+    #[test]
+    fn test_classify_retry_action_json_parse() {
+        let err = format!(
+            "{}: invalid token",
+            crate::messages::error::JSON_PARSE_FAILED_MARKER
+        );
+        assert_eq!(classify_retry_action(&err), RetryAction::JsonParse);
+    }
+
+    #[tokio::test]
+    async fn test_collect_ordered_outcomes_returns_error_on_failure() {
+        let mut inflight = stream::iter(vec![
+            Err::<PlannedSessionOutcome, AnalyzerError>("boom".into()),
+            Ok(sample_outcome(0, "s-ok")),
+        ]);
+
+        let result = collect_ordered_outcomes(&mut inflight, 2, false).await;
+        let err = match result {
+            Ok(_) => panic!("must fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn test_collect_ordered_outcomes_places_by_plan_index() {
+        let mut inflight = stream::iter(vec![
+            Ok(sample_outcome(1, "s-2")),
+            Ok(sample_outcome(0, "s-1")),
+        ]);
+
+        let ordered = collect_ordered_outcomes(&mut inflight, 2, false)
+            .await
+            .unwrap();
+        assert_eq!(ordered[0].as_ref().unwrap().session_id, "s-1");
+        assert_eq!(ordered[1].as_ref().unwrap().session_id, "s-2");
+    }
+
+    #[test]
+    fn test_merge_ordered_outcomes_rejects_missing_sessions() {
+        let ordered = vec![Some(sample_outcome(0, "s-1")), None];
+        let result = merge_ordered_outcomes(ordered);
+        let err = match result {
+            Ok(_) => panic!("must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.to_string(), crate::messages::error::ALL_SESSIONS_FAILED);
+    }
+
+    #[test]
+    fn test_merge_ordered_outcomes_keeps_plan_order() {
+        let ordered = vec![
+            Some(sample_outcome(0, "s-1")),
+            Some(sample_outcome(1, "s-2")),
+        ];
+        let (results, redact) = merge_ordered_outcomes(ordered).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].sessions[0].session_id, "s-1");
+        assert_eq!(results[1].sessions[0].session_id, "s-2");
+        assert_eq!(redact.total_count, 0);
+    }
 }

--- a/src/analyzer/planner.rs
+++ b/src/analyzer/planner.rs
@@ -13,7 +13,6 @@ pub struct RateLimits {
 
 impl RateLimits {
     /// Generous defaults used when probing fails.
-    /// Most users will proceed with single_shot; the runtime safety net handles actual limits.
     pub fn default_generous() -> Self {
         Self {
             input_tokens_per_minute: 1_000_000,
@@ -48,63 +47,33 @@ pub struct ExecutionStep {
 }
 
 /// Overall execution plan.
-/// When is_single_shot is true, all sessions are sent in one API call (no overhead for high-tier users).
 #[derive(Debug, Clone)]
 pub struct ExecutionPlan {
     pub rate_limits: RateLimits,
     pub steps: Vec<ExecutionStep>,
     pub total_estimated_tokens: u64,
-    pub is_single_shot: bool,
-    /// Dynamic max_tokens value for API calls.
-    pub recommended_max_tokens: u64,
 }
-
-/// Token budget reserved for the analyze_summary() call.
-const SUMMARY_BUDGET_TOKENS: u64 = 5_000;
-
-/// Estimated output tokens per session (conservative: ~1500 based on real-world measurements).
-const OUTPUT_TOKENS_PER_SESSION: u64 = 1_500;
-
-/// Output margin ratio (30%).
-const OUTPUT_MARGIN: f64 = 1.3;
 
 /// Builds an execution plan from rate limits and per-session estimates.
 ///
 /// Strategy branches:
-/// - total + budget <= ITPM AND estimated output <= model_max_output -> single_shot
-/// - individual session <= ITPM -> Direct (sequential per-session)
+/// - individual session <= ITPM -> Direct
 /// - individual session > ITPM -> Summarize (chunk and summarize)
 pub fn build_execution_plan(
     limits: &RateLimits,
     estimates: &[SessionEstimate],
-    model_max_output: u64,
+    _model_max_output: u64,
 ) -> ExecutionPlan {
-    let itpm = limits.input_tokens_per_minute;
+    let safe_itpm = limits.input_tokens_per_minute.max(1);
     let total: u64 = estimates.iter().map(|e| e.estimated_tokens).sum();
-    let num_sessions = estimates.len() as u64;
 
-    let estimated_output = (num_sessions * OUTPUT_TOKENS_PER_SESSION) as f64 * OUTPUT_MARGIN;
-    let recommended_max_tokens = (estimated_output as u64).min(model_max_output);
-
-    // Single-shot condition: both input AND output fit within limits.
-    if total + SUMMARY_BUDGET_TOKENS <= itpm && (estimated_output as u64) <= model_max_output {
-        return ExecutionPlan {
-            rate_limits: limits.clone(),
-            steps: Vec::new(),
-            total_estimated_tokens: total,
-            is_single_shot: true,
-            recommended_max_tokens,
-        };
-    }
-
-    // Per-session strategy selection.
     let steps: Vec<ExecutionStep> = estimates
         .iter()
         .map(|est| {
-            let strategy = if est.estimated_tokens <= itpm {
+            let strategy = if est.estimated_tokens <= safe_itpm {
                 StepStrategy::Direct
             } else {
-                let chunks = ((est.estimated_tokens as f64) / (itpm as f64)).ceil() as usize;
+                let chunks = ((est.estimated_tokens as f64) / (safe_itpm as f64)).ceil() as usize;
                 StepStrategy::Summarize {
                     chunks: chunks.max(2),
                 }
@@ -121,8 +90,6 @@ pub fn build_execution_plan(
         rate_limits: limits.clone(),
         steps,
         total_estimated_tokens: total,
-        is_single_shot: false,
-        recommended_max_tokens,
     }
 }
 
@@ -136,29 +103,6 @@ mod tests {
         assert_eq!(limits.input_tokens_per_minute, 1_000_000);
         assert_eq!(limits.output_tokens_per_minute, 200_000);
         assert_eq!(limits.requests_per_minute, 1_000);
-    }
-
-    #[test]
-    fn test_build_plan_single_shot_when_total_fits() {
-        let limits = RateLimits {
-            input_tokens_per_minute: 100_000,
-            output_tokens_per_minute: 50_000,
-            requests_per_minute: 100,
-        };
-        let estimates = vec![
-            SessionEstimate {
-                session_id: "s1".into(),
-                estimated_tokens: 10_000,
-            },
-            SessionEstimate {
-                session_id: "s2".into(),
-                estimated_tokens: 20_000,
-            },
-        ];
-        let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(plan.is_single_shot);
-        assert!(plan.steps.is_empty());
-        assert_eq!(plan.total_estimated_tokens, 30_000);
     }
 
     #[test]
@@ -179,7 +123,6 @@ mod tests {
             },
         ];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(!plan.is_single_shot);
         assert_eq!(plan.steps.len(), 2);
         assert_eq!(plan.steps[0].strategy, StepStrategy::Direct);
         assert_eq!(plan.steps[1].strategy, StepStrategy::Direct);
@@ -197,7 +140,6 @@ mod tests {
             estimated_tokens: 50_000,
         }];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(!plan.is_single_shot);
         assert_eq!(plan.steps.len(), 1);
         assert_eq!(
             plan.steps[0].strategy,
@@ -206,87 +148,19 @@ mod tests {
     }
 
     #[test]
-    fn test_build_plan_default_generous_is_single_shot() {
-        let limits = RateLimits::default_generous();
-        let estimates = vec![SessionEstimate {
-            session_id: "s1".into(),
-            estimated_tokens: 50_000,
-        }];
-        let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(plan.is_single_shot);
-    }
-
-    #[test]
-    fn test_build_plan_reserves_summary_budget() {
-        let limits = RateLimits {
-            input_tokens_per_minute: 35_000,
-            output_tokens_per_minute: 8_000,
-            requests_per_minute: 50,
-        };
-        let estimates = vec![SessionEstimate {
-            session_id: "s1".into(),
-            estimated_tokens: 31_000,
-        }];
-        let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(!plan.is_single_shot);
-    }
-
-    #[test]
-    fn test_build_plan_exact_boundary_is_single_shot() {
-        let limits = RateLimits {
-            input_tokens_per_minute: 35_000,
-            output_tokens_per_minute: 8_000,
-            requests_per_minute: 50,
-        };
-        let estimates = vec![SessionEstimate {
-            session_id: "s1".into(),
-            estimated_tokens: 30_000,
-        }];
-        let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(plan.is_single_shot);
-    }
-
-    #[test]
-    fn test_single_shot_blocked_by_output_limit() {
-        let limits = RateLimits::default_generous();
-        let estimates: Vec<SessionEstimate> = (0..22)
-            .map(|i| SessionEstimate {
-                session_id: format!("s{i}"),
-                estimated_tokens: 10_000,
-            })
-            .collect();
-        let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(!plan.is_single_shot);
-        assert!(!plan.steps.is_empty());
-    }
-
-    #[test]
-    fn test_single_shot_allowed_when_output_fits() {
+    fn test_build_plan_total_estimated_tokens_is_sum() {
         let limits = RateLimits::default_generous();
         let estimates = vec![
             SessionEstimate {
                 session_id: "s1".into(),
-                estimated_tokens: 50_000,
+                estimated_tokens: 5_000,
             },
             SessionEstimate {
                 session_id: "s2".into(),
-                estimated_tokens: 30_000,
+                estimated_tokens: 7_000,
             },
         ];
         let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert!(plan.is_single_shot);
-    }
-
-    #[test]
-    fn test_recommended_max_tokens_scales_with_sessions() {
-        let limits = RateLimits::default_generous();
-        let estimates: Vec<SessionEstimate> = (0..10)
-            .map(|i| SessionEstimate {
-                session_id: format!("s{i}"),
-                estimated_tokens: 5_000,
-            })
-            .collect();
-        let plan = build_execution_plan(&limits, &estimates, 32_000);
-        assert_eq!(plan.recommended_max_tokens, 19_500);
+        assert_eq!(plan.total_estimated_tokens, 12_000);
     }
 }

--- a/src/analyzer/prompt.rs
+++ b/src/analyzer/prompt.rs
@@ -178,6 +178,23 @@ pub fn build_codex_prompt(
     Ok(output)
 }
 
+/// Extracts (role, text) tuples from Codex entries.
+pub fn extract_codex_messages(entries: &[CodexEntry]) -> Vec<(String, String)> {
+    let mut messages = Vec::new();
+    for entry in entries {
+        match entry {
+            CodexEntry::UserMessage { text, .. } if !text.is_empty() => {
+                messages.push(("USER".to_string(), text.clone()));
+            }
+            CodexEntry::AssistantMessage { text, .. } if !text.is_empty() => {
+                messages.push(("ASSISTANT".to_string(), text.clone()));
+            }
+            _ => {}
+        }
+    }
+    messages
+}
+
 /// Extracts unique session IDs from LogEntries, preserving insertion order.
 /// Used to split entries by session during fallback execution.
 pub fn extract_session_ids(entries: &[LogEntry]) -> Vec<String> {
@@ -209,6 +226,11 @@ pub const SYSTEM_PROMPT_ESTIMATED_TOKENS: u64 = 1_300;
 /// Korean syllables are ~1 token each, so char_count / 2 is a conservative estimate.
 pub fn estimate_tokens(text: &str) -> u64 {
     (text.chars().count() as u64) / 2
+}
+
+/// Estimates session tokens from a pre-built prompt text.
+pub fn estimate_prompt_tokens(prompt_text: &str) -> u64 {
+    estimate_tokens(prompt_text) + SYSTEM_PROMPT_ESTIMATED_TOKENS
 }
 
 /// Returns per-session token estimates.
@@ -348,6 +370,39 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_codex_messages_keeps_user_and_assistant_only() {
+        use crate::parser::codex::CodexEntry;
+        let entries = vec![
+            CodexEntry::SessionMeta {
+                timestamp: "2026-03-11T09:59:00Z".parse().unwrap(),
+                session_id: "s1".to_string(),
+                cwd: "/tmp".to_string(),
+                model_provider: "openai".to_string(),
+            },
+            CodexEntry::UserMessage {
+                timestamp: "2026-03-11T10:00:00Z".parse().unwrap(),
+                text: "질문".to_string(),
+            },
+            CodexEntry::AssistantMessage {
+                timestamp: "2026-03-11T10:00:10Z".parse().unwrap(),
+                text: "답변".to_string(),
+            },
+            CodexEntry::FunctionCall {
+                timestamp: "2026-03-11T10:00:20Z".parse().unwrap(),
+                name: "Read".to_string(),
+            },
+        ];
+        let messages = extract_codex_messages(&entries);
+        assert_eq!(
+            messages,
+            vec![
+                ("USER".to_string(), "질문".to_string()),
+                ("ASSISTANT".to_string(), "답변".to_string())
+            ]
+        );
+    }
+
+    #[test]
     fn test_extract_session_ids_dedup_preserves_order() {
         let entries = vec![
             serde_json::from_str::<LogEntry>(
@@ -392,6 +447,12 @@ mod tests {
     #[test]
     fn test_estimate_tokens_empty_string() {
         assert_eq!(super::estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn test_estimate_prompt_tokens_includes_system_overhead() {
+        let tokens = estimate_prompt_tokens("hello");
+        assert!(tokens > estimate_tokens("hello"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,11 +521,15 @@ async fn run_today(
         sources.push(("Claude Code".to_string(), result));
     }
 
-    // Codex analysis — runs after Claude spinner finishes; fast enough to skip a spinner.
-    for (summary, entries) in &codex_sessions {
+    // Codex analysis — unified session pipeline (same executor as Claude).
+    if !codex_sessions.is_empty() {
+        let mut codex_tasks = Vec::new();
+        for (summary, entries) in &codex_sessions {
+            let task = analyzer::build_codex_session_task(entries, &summary.session_id)?;
+            codex_tasks.push(task);
+        }
         let (result, redact_result) =
-            analyzer::analyze_codex_entries(entries, &summary.session_id, redactor_enabled, &lang)
-                .await?;
+            analyzer::analyze_session_tasks(codex_tasks, redactor_enabled, verbose, &lang).await?;
         total_redact.merge(redact_result);
         sources.push(("Codex".to_string(), result));
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -294,7 +294,6 @@ pub mod status {
     pub const SLACK_GENERATING: &str = "Generating Slack message...";
     pub const COPIED_TO_CLIPBOARD: &str = "Copied to clipboard.";
     pub const PROBING_RATE_LIMITS: &str = "Checking API rate limits...";
-    pub const ANALYZING_INSIGHT: &str = "Analyzing insights...";
 
     pub fn analyzing(provider: &str) -> String {
         format!("Analyzing insights via {provider}...")
@@ -337,41 +336,6 @@ pub mod status {
         format!("\u{2713} [{i}/{total}] Done")
     }
 
-    pub fn step_retry_success(i: usize, total: usize) -> String {
-        format!("\u{2713} [{i}/{total}] Retry succeeded")
-    }
-
-    pub fn step_reanalysis_success(i: usize, total: usize) -> String {
-        format!("\u{2713} [{i}/{total}] Re-analysis succeeded")
-    }
-
-    pub fn step_skip(
-        i: usize,
-        total: usize,
-        session_id: &str,
-        reason: &dyn std::fmt::Display,
-    ) -> String {
-        format!("\u{26A0} [{i}/{total}] {session_id} skipped: {reason}")
-    }
-
-    pub fn step_skip_retry(
-        i: usize,
-        total: usize,
-        session_id: &str,
-        reason: &dyn std::fmt::Display,
-    ) -> String {
-        format!("\u{26A0} [{i}/{total}] {session_id} skipped (retry failed): {reason}")
-    }
-
-    pub fn step_skip_reanalysis(
-        i: usize,
-        total: usize,
-        session_id: &str,
-        reason: &dyn std::fmt::Display,
-    ) -> String {
-        format!("\u{26A0} [{i}/{total}] {session_id} skipped (re-analysis failed): {reason}")
-    }
-
     pub fn chunk_summarizing(i: usize, total: usize) -> String {
         format!("Summarizing chunk {i}/{total}...")
     }
@@ -380,12 +344,8 @@ pub mod status {
         format!("    \u{2713} Chunk {i}/{total} done")
     }
 
-    pub fn plan_single_shot(estimated_tokens: u64) -> String {
-        format!("\u{2713} Analyzing full log in one pass (est. {estimated_tokens} tokens)")
-    }
-
     pub fn plan_multi_step(steps: usize, total_tokens: u64) -> String {
-        format!("\u{2713} Analyzing {steps} sessions sequentially (est. {total_tokens} tokens)")
+        format!("\u{2713} Analyzing {steps} sessions (est. {total_tokens} tokens)")
     }
 
     pub fn plan_step_direct(session_id: &str, tokens: u64) -> String {
@@ -600,10 +560,6 @@ pub mod verbose {
                 session_id
             },
         )
-    }
-
-    pub fn api_done_single(secs: f64, input: u64, output: u64) -> String {
-        format!("\u{2713} Done in {secs:.1}s (input: {input} / output: {output})")
     }
 
     pub fn cache_saved(path: &dyn std::fmt::Display, size_kb: f64) -> String {

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -764,9 +764,8 @@ mod tests {
         let kept_texts: Vec<&str> = filtered
             .iter()
             .filter_map(|entry| match entry {
-                CodexEntry::UserMessage { text, .. } | CodexEntry::AssistantMessage { text, .. } => {
-                    Some(text.as_str())
-                }
+                CodexEntry::UserMessage { text, .. }
+                | CodexEntry::AssistantMessage { text, .. } => Some(text.as_str()),
                 _ => None,
             })
             .collect();


### PR DESCRIPTION
## Summary\n- unify Claude/API and Codex session analysis into a shared session-task pipeline\n- execute session analysis in parallel with provider-aware worker caps\n- enforce retry policy (429 wait/retry, JSON reanalyze) and fail-fast semantics\n- move Codex exec calls to spawn_blocking to avoid async runtime blocking\n- add targeted tests for retry classification and ordered parallel outcome merge\n\n## Verification\n- cargo build\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test (173 passed)\n- sandbox validation with OpenAI/Anthropic/Codex providers