### PR TITLE
feat: add rwd version command while preserving --version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,7 @@ Examples:
   rwd reset --dry-run               Preview files that reset will remove
   rwd reset --yes                   Reset config/cache without confirmation
   rwd doctor                        Run environment and install diagnostics
+  rwd version                       Print current rwd version
   rwd update                        Update to the latest version"
 )]
 pub struct Cli {
@@ -141,10 +142,37 @@ Example:
     },
     /// Run environment and install diagnostics
     Doctor,
+    /// Print current rwd version
+    Version,
 }
 
 #[derive(Subcommand)]
 pub enum AuthAction {
     /// Show provider auth method and credential state
     Status,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Commands};
+    use clap::error::ErrorKind;
+    use clap::Parser;
+
+    #[test]
+    fn test_parse_version_subcommand() {
+        let parsed = Cli::try_parse_from(["rwd", "version"]);
+        assert!(parsed.is_ok());
+        if let Ok(cli) = parsed {
+            assert!(matches!(cli.command, Commands::Version));
+        }
+    }
+
+    #[test]
+    fn test_parse_version_flag_displays_version() {
+        let parsed = Cli::try_parse_from(["rwd", "--version"]);
+        assert!(parsed.is_err());
+        if let Err(err) = parsed {
+            assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn main() {
     // Worker mode skips this to avoid blocking (no terminal).
     let skip_update = matches!(
         args.command,
-        Commands::Update | Commands::Doctor | Commands::Reset { .. }
+        Commands::Update | Commands::Doctor | Commands::Reset { .. } | Commands::Version
     ) || matches!(args.command, Commands::Today { worker: true, .. });
     if !skip_update {
         update::notify_if_update_available().await;
@@ -126,6 +126,9 @@ async fn main() {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }
+        }
+        Commands::Version => {
+            println!("rwd {}", env!("CARGO_PKG_VERSION"));
         }
         Commands::Auth { action } => match action {
             AuthAction::Status => {


### PR DESCRIPTION
## Summary
- add `version` subcommand to print current rwd version
- keep clap default `--version` flag behavior for compatibility
- add CLI parser tests for both `rwd version` and `rwd --version`
- skip update notification for the explicit `version` subcommand path

## Validation
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
