### PR TITLE
perf(today): compact log runs and drop tool payloads from analysis prompts

### DIFF
--- a/src/analyzer/compaction.rs
+++ b/src/analyzer/compaction.rs
@@ -1,0 +1,617 @@
+// Detects log-like regions *inside* a message and compacts only those regions,
+// preserving any natural-language lines interleaved with the logs.
+//
+// Edge cases explicitly handled below:
+//   - Empty input.
+//   - Text under MIN_COMPACT_BYTES (left verbatim).
+//   - A single huge line without any newline (no log runs).
+//   - All-prose text (untouched; no runs).
+//   - All-log text (single run, compacted).
+//   - Log run sandwiched between two prose lines ("한 줄 질문 ... 로그 ... 질문").
+//   - Multiple interleaved log runs (each compacted independently).
+//   - Very short log run (< MIN_RUN_LINES or < MIN_RUN_BYTES): left as-is.
+//   - Windows line endings (\r\n) and the Unicode line separator (U+2028).
+//   - Trailing newline is preserved exactly (present iff original had one).
+//   - Blank / whitespace / extremely short lines inside a run are absorbed,
+//     but trailing Neutral lines bordering prose are not included in the run.
+//   - Version strings ("v1.0.106") are NOT misclassified as prose.
+//   - Repeated prefixes like "   Compiling", "flutter: " promote ambiguous
+//     lines to Log via prefix-repetition detection.
+//   - Result is guaranteed to be no larger than the input (falls back to the
+//     original string when compaction accidentally grows the text).
+//   - All slicing respects UTF-8 char boundaries.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Messages smaller than this byte count are never inspected or rewritten.
+const MIN_COMPACT_BYTES: usize = 8 * 1024;
+/// A contiguous log run shorter than this many lines is left verbatim.
+const MIN_RUN_LINES: usize = 20;
+/// A run smaller than this many bytes is left verbatim.
+const MIN_RUN_BYTES: usize = 2 * 1024;
+/// Lines kept from the head of a compacted run.
+const RUN_HEAD_LINES: usize = 5;
+/// Lines kept from the tail of a compacted run.
+const RUN_TAIL_LINES: usize = 3;
+/// Byte window used to detect repeated line-start prefixes.
+const PREFIX_WINDOW_BYTES: usize = 8;
+/// Minimum number of consecutive lines sharing a prefix to promote to Log.
+const PREFIX_REPEAT_MIN: usize = 10;
+/// Minimum trimmed length before a line can receive a non-Neutral class.
+const MIN_CLASSIFIABLE_LEN: usize = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LineClass {
+    Log,
+    Prose,
+    Neutral,
+}
+
+fn stack_trace_line_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"^(?:",
+            r"\s*at\s+\S+\(.+?:\d+\)",
+            r#"|\s+File\s+"[^"]+",\s+line\s+\d+"#,
+            r"|\s*Traceback\s*\(most recent call last\):",
+            r"|\s*Caused by:",
+            r")",
+        ))
+        .expect("valid stack trace regex")
+    })
+}
+
+fn timestamp_line_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"^\s*(?:",
+            r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}",
+            r"|\d{2}:\d{2}:\d{2}(?:[.,]\d{3})?\b",
+            r")",
+        ))
+        .expect("valid timestamp regex")
+    })
+}
+
+fn prompt_line_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"(?i)^\s*(?:",
+            r"\$\s",
+            r"|>>>\s",
+            r"|#\s",
+            r"|npm\s+ERR!",
+            r"|error[:\[]",
+            r"|warning:",
+            r"|panicked at",
+            r"|thread\s+'.*?'\s+panicked",
+            r"|FAILED",
+            r"|fatal:",
+            r")",
+        ))
+        .expect("valid prompt regex")
+    })
+}
+
+/// Replace every detected log run inside `text` with a compact head/tail
+/// summary, while leaving prose and short log fragments untouched.
+pub fn compact_log_like(text: &str) -> String {
+    if text.is_empty() || text.len() <= MIN_COMPACT_BYTES {
+        return text.to_string();
+    }
+
+    let trailing_newline = text.ends_with('\n');
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.is_empty() {
+        return text.to_string();
+    }
+
+    let mut classes = initial_line_classes(&lines);
+    promote_prefix_runs(&lines, &mut classes);
+    let runs = find_log_runs(&classes);
+
+    if runs.is_empty() {
+        return text.to_string();
+    }
+
+    let compacted = rewrite(&lines, &runs, trailing_newline);
+    if compacted.len() >= text.len() {
+        text.to_string()
+    } else {
+        compacted
+    }
+}
+
+/// Reports whether `text` contains at least one compactable log run.
+/// Returns false for small or purely natural-language inputs.
+#[allow(dead_code)]
+pub fn is_log_like(text: &str) -> bool {
+    if text.len() <= MIN_COMPACT_BYTES {
+        return false;
+    }
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.is_empty() {
+        return false;
+    }
+    let mut classes = initial_line_classes(&lines);
+    promote_prefix_runs(&lines, &mut classes);
+    !find_log_runs(&classes).is_empty()
+}
+
+fn initial_line_classes(lines: &[&str]) -> Vec<LineClass> {
+    lines.iter().map(|l| classify_line_strict(l)).collect()
+}
+
+fn classify_line_strict(line: &str) -> LineClass {
+    if line.trim().len() < MIN_CLASSIFIABLE_LEN {
+        return LineClass::Neutral;
+    }
+    if line.contains('\u{001b}')
+        || stack_trace_line_regex().is_match(line)
+        || timestamp_line_regex().is_match(line)
+        || prompt_line_regex().is_match(line)
+    {
+        return LineClass::Log;
+    }
+    if looks_like_prose(line) {
+        return LineClass::Prose;
+    }
+    LineClass::Neutral
+}
+
+/// Prose heuristic: the line ends with sentence-ending punctuation that is
+/// preceded by an alphabetic character (letter / Hangul / etc.). Trailing "."
+/// after a digit ("v1.0.106", "foo.bar:42") does NOT qualify.
+fn looks_like_prose(line: &str) -> bool {
+    let trimmed = line.trim_end();
+    let mut iter = trimmed.chars().rev();
+    let Some(last) = iter.next() else {
+        return false;
+    };
+    if !matches!(last, '.' | '!' | '?' | '。' | '！' | '？') {
+        return false;
+    }
+    let Some(before) = iter.next() else {
+        return false;
+    };
+    before.is_alphabetic()
+}
+
+/// Promote Ambiguous/Neutral lines to Log when a shared 8-byte line-start
+/// prefix repeats PREFIX_REPEAT_MIN times in a row. Handles patterns such as
+/// "   Compiling foo v1.0", "flutter: [tag] ...", "INFO 2026-...".
+fn promote_prefix_runs(lines: &[&str], classes: &mut [LineClass]) {
+    let mut i = 0;
+    while i < lines.len() {
+        if classes[i] == LineClass::Prose {
+            i += 1;
+            continue;
+        }
+        let Some(prefix) = prefix_window(lines[i]) else {
+            i += 1;
+            continue;
+        };
+        let mut j = i + 1;
+        while j < lines.len()
+            && classes[j] != LineClass::Prose
+            && prefix_window(lines[j]) == Some(prefix)
+        {
+            j += 1;
+        }
+        if j - i >= PREFIX_REPEAT_MIN {
+            for entry in classes.iter_mut().take(j).skip(i) {
+                *entry = LineClass::Log;
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+fn prefix_window(line: &str) -> Option<&str> {
+    if line.len() < PREFIX_WINDOW_BYTES {
+        return None;
+    }
+    let end = ceil_char_boundary(line, PREFIX_WINDOW_BYTES);
+    Some(&line[..end])
+}
+
+/// Locate contiguous runs of Log (allowing interior Neutral) bounded by Prose
+/// or input edges. Trailing Neutral lines bordering prose are excluded.
+fn find_log_runs(classes: &[LineClass]) -> Vec<(usize, usize)> {
+    let mut runs = Vec::new();
+    let mut i = 0;
+    while i < classes.len() {
+        if classes[i] != LineClass::Log {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut j = i + 1;
+        while j < classes.len() {
+            match classes[j] {
+                LineClass::Log | LineClass::Neutral => j += 1,
+                LineClass::Prose => break,
+            }
+        }
+        let mut end = j;
+        while end > start && classes[end - 1] == LineClass::Neutral {
+            end -= 1;
+        }
+        if end > start {
+            runs.push((start, end));
+        }
+        i = j.max(start + 1);
+    }
+    runs
+}
+
+fn byte_count_of_lines(lines: &[&str], start: usize, end: usize) -> usize {
+    lines[start..end].iter().map(|l| l.len() + 1).sum()
+}
+
+fn rewrite(lines: &[&str], runs: &[(usize, usize)], trailing_newline: bool) -> String {
+    let capacity_hint = lines.iter().map(|l| l.len() + 1).sum::<usize>();
+    let mut out = String::with_capacity(capacity_hint);
+    let mut cursor = 0;
+    for &(start, end) in runs {
+        for line in &lines[cursor..start] {
+            out.push_str(line);
+            out.push('\n');
+        }
+
+        let run_lines = end - start;
+        let run_bytes = byte_count_of_lines(lines, start, end);
+        if run_lines >= MIN_RUN_LINES && run_bytes >= MIN_RUN_BYTES {
+            write_compacted_run(&mut out, lines, start, end);
+        } else {
+            for line in &lines[start..end] {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+
+        cursor = end;
+    }
+    for line in &lines[cursor..] {
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    if !trailing_newline && out.ends_with('\n') {
+        out.pop();
+    }
+
+    out
+}
+
+fn write_compacted_run(out: &mut String, lines: &[&str], start: usize, end: usize) {
+    let head_end = (start + RUN_HEAD_LINES).min(end);
+    let tail_start = end.saturating_sub(RUN_TAIL_LINES).max(head_end);
+
+    for line in &lines[start..head_end] {
+        out.push_str(line);
+        out.push('\n');
+    }
+    let omitted_lines = tail_start - head_end;
+    if omitted_lines > 0 {
+        let omitted_bytes = byte_count_of_lines(lines, head_end, tail_start);
+        out.push_str("… [");
+        out.push_str(&omitted_lines.to_string());
+        out.push_str(" log-like lines, ");
+        out.push_str(&omitted_bytes.to_string());
+        out.push_str(" bytes omitted] …\n");
+    }
+    for line in &lines[tail_start..end] {
+        out.push_str(line);
+        out.push('\n');
+    }
+}
+
+fn ceil_char_boundary(s: &str, mut idx: usize) -> usize {
+    if idx >= s.len() {
+        return s.len();
+    }
+    while idx < s.len() && !s.is_char_boundary(idx) {
+        idx += 1;
+    }
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cargo_line(i: usize) -> String {
+        format!("   Compiling foo v1.0.{i}\n")
+    }
+
+    fn big_cargo_block(n: usize) -> String {
+        (0..n).map(cargo_line).collect()
+    }
+
+    fn big_flutter_block(n: usize) -> String {
+        let line =
+            "flutter: ✅ [Sounds] 경로 기반 프리로드 완료 (성공: 63, 실패: 0)\n";
+        line.repeat(n)
+    }
+
+    fn pad_log(size: usize) -> String {
+        let line = "\u{001b}[0;31merror\u{001b}[0m build failed for target\n";
+        let mut s = String::new();
+        while s.len() < size {
+            s.push_str(line);
+        }
+        s
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(compact_log_like(""), "");
+    }
+
+    #[test]
+    fn under_min_size_pass_through() {
+        let s = "\u{001b}[31merror\u{001b}[0m boom\n".repeat(20);
+        assert!(s.len() < MIN_COMPACT_BYTES);
+        assert_eq!(compact_log_like(&s), s);
+    }
+
+    #[test]
+    fn single_long_line_without_newline_pass_through() {
+        let s = "a".repeat(20_000);
+        assert_eq!(compact_log_like(&s), s);
+    }
+
+    #[test]
+    fn all_prose_paragraphs_pass_through() {
+        let mut s = String::new();
+        for i in 0..1000 {
+            s.push_str(&format!(
+                "이 문단은 {i}번째 설명입니다. 기능 요청을 검토하고 우선순위를 정합니다.\n"
+            ));
+        }
+        assert!(s.len() > MIN_COMPACT_BYTES);
+        assert_eq!(compact_log_like(&s), s);
+    }
+
+    #[test]
+    fn ansi_log_block_compacted() {
+        let s = pad_log(40_000);
+        let out = compact_log_like(&s);
+        assert!(out.len() < s.len());
+        assert!(out.contains("log-like lines"));
+    }
+
+    #[test]
+    fn stack_trace_compacted() {
+        let mut s = String::from("Traceback (most recent call last):\n");
+        for _ in 0..500 {
+            s.push_str("    at com.example.Foo.bar(Foo.java:42)\n");
+        }
+        let out = compact_log_like(&s);
+        assert!(out.len() < s.len());
+        assert!(out.contains("log-like lines"));
+    }
+
+    #[test]
+    fn timestamp_log_compacted() {
+        let line = "2026-04-17 12:00:00 INFO service tick with config foo=bar\n";
+        let s = line.repeat(500);
+        let out = compact_log_like(&s);
+        assert!(out.len() < s.len());
+    }
+
+    #[test]
+    fn flutter_prefix_log_compacted() {
+        let s = big_flutter_block(600);
+        let out = compact_log_like(&s);
+        assert!(out.len() < s.len(), "flutter log should compact");
+        assert!(out.contains("log-like lines"));
+    }
+
+    #[test]
+    fn cargo_build_log_compacted_via_prefix_repeat() {
+        let s = big_cargo_block(600);
+        assert!(s.len() > MIN_COMPACT_BYTES);
+        let out = compact_log_like(&s);
+        assert!(
+            out.len() < s.len(),
+            "cargo build log ({} bytes) should compact, got {} bytes",
+            s.len(),
+            out.len()
+        );
+        assert!(out.contains("log-like lines"));
+    }
+
+    #[test]
+    fn prose_inside_log_run_is_preserved() {
+        let mut s = String::new();
+        s.push_str(&big_cargo_block(600));
+        s.push_str("왜 이래?\n");
+        s.push_str(&big_cargo_block(600));
+        let out = compact_log_like(&s);
+        assert!(
+            out.contains("왜 이래?"),
+            "prose sandwiched between logs must survive"
+        );
+        assert_eq!(
+            out.matches("log-like lines").count(),
+            2,
+            "two runs should be compacted separately"
+        );
+    }
+
+    #[test]
+    fn prose_leading_and_trailing_runs_preserved() {
+        let mut s = String::new();
+        s.push_str("이거 돌렸더니 뭔가 이상해.\n");
+        s.push_str(&big_cargo_block(600));
+        s.push_str("어떻게 생각해?\n");
+        let out = compact_log_like(&s);
+        assert!(out.contains("이거 돌렸더니 뭔가 이상해."));
+        assert!(out.contains("어떻게 생각해?"));
+        assert!(out.contains("log-like lines"));
+    }
+
+    #[test]
+    fn short_log_run_not_compacted() {
+        let mut s = String::new();
+        s.push_str(&"x".repeat(MIN_COMPACT_BYTES + 100));
+        s.push('\n');
+        for _ in 0..5 {
+            s.push_str("    at com.example.Foo.bar(Foo.java:42)\n");
+        }
+        let out = compact_log_like(&s);
+        assert!(!out.contains("log-like lines"));
+    }
+
+    #[test]
+    fn trailing_newline_preserved_when_present() {
+        let s = big_cargo_block(600);
+        assert!(s.ends_with('\n'));
+        let out = compact_log_like(&s);
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn no_trailing_newline_preserved_when_absent() {
+        let mut s = big_cargo_block(600);
+        s.pop();
+        assert!(!s.ends_with('\n'));
+        let out = compact_log_like(&s);
+        assert!(!out.ends_with('\n'));
+    }
+
+    #[test]
+    fn windows_line_endings_still_compacted() {
+        let line = "   Compiling foo v1.0.0\r\n";
+        let s = line.repeat(600);
+        let out = compact_log_like(&s);
+        assert!(out.len() < s.len());
+    }
+
+    #[test]
+    fn utf8_safe_when_head_boundary_crosses_hangul() {
+        let prefix = "한글".repeat(3);
+        let mut s = String::new();
+        s.push_str(&prefix);
+        s.push('\n');
+        s.push_str(&big_cargo_block(600));
+        let out = compact_log_like(&s);
+        assert!(out.is_char_boundary(0));
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+        assert!(out.starts_with(&prefix));
+    }
+
+    #[test]
+    fn compaction_never_grows_text() {
+        for n in [5usize, 10, 30, 100, 400, 800] {
+            let s = big_cargo_block(n);
+            if s.len() < MIN_COMPACT_BYTES {
+                continue;
+            }
+            let out = compact_log_like(&s);
+            assert!(
+                out.len() <= s.len(),
+                "compaction grew text at n={n}: {} > {}",
+                out.len(),
+                s.len()
+            );
+        }
+    }
+
+    #[test]
+    fn version_strings_are_not_prose() {
+        assert!(!looks_like_prose("package v1.0.106"));
+        assert!(!looks_like_prose("  _flutterfire_internals 1.3.68"));
+    }
+
+    #[test]
+    fn english_and_korean_sentences_are_prose() {
+        assert!(looks_like_prose("Today we discussed the new feature."));
+        assert!(looks_like_prose("왜 이래?"));
+        assert!(looks_like_prose("정말 멋진 아이디어야!"));
+    }
+
+    #[test]
+    fn run_absorbs_blank_lines_inside_log() {
+        let mut s = String::new();
+        s.push_str(&big_cargo_block(300));
+        s.push('\n');
+        s.push_str(&big_cargo_block(300));
+        let out = compact_log_like(&s);
+        assert!(out.len() < s.len());
+        assert_eq!(
+            out.matches("log-like lines").count(),
+            1,
+            "blank line should be absorbed into one run"
+        );
+    }
+
+    #[test]
+    fn multiple_interleaved_runs_each_compacted() {
+        let mut s = String::new();
+        for _ in 0..3 {
+            s.push_str("지금 확인해볼게.\n");
+            s.push_str(&big_cargo_block(600));
+        }
+        let out = compact_log_like(&s);
+        assert_eq!(out.matches("log-like lines").count(), 3);
+        assert_eq!(out.matches("지금 확인해볼게.").count(), 3);
+    }
+
+    #[test]
+    fn all_log_text_results_in_single_compacted_run() {
+        let s = big_cargo_block(800);
+        let out = compact_log_like(&s);
+        assert_eq!(out.matches("log-like lines").count(), 1);
+        assert!(out.len() < s.len());
+    }
+
+    #[test]
+    fn is_log_like_detects_run() {
+        let s = big_cargo_block(600);
+        assert!(is_log_like(&s));
+    }
+
+    #[test]
+    fn is_log_like_rejects_prose() {
+        let mut s = String::new();
+        for i in 0..500 {
+            s.push_str(&format!(
+                "{i}번째 문단으로 기능을 검토합니다. 대안도 함께 정리합니다.\n"
+            ));
+        }
+        assert!(s.len() > MIN_COMPACT_BYTES);
+        assert!(!is_log_like(&s));
+    }
+
+    #[test]
+    fn is_log_like_rejects_tiny_text() {
+        assert!(!is_log_like("short"));
+        assert!(!is_log_like(&pad_log(2_000)));
+    }
+
+    #[test]
+    fn dashes_and_fences_are_neutral_not_prose() {
+        assert_eq!(classify_line_strict("---"), LineClass::Neutral);
+        assert_eq!(classify_line_strict("```"), LineClass::Neutral);
+        assert_eq!(classify_line_strict("```rust"), LineClass::Neutral);
+    }
+
+    #[test]
+    fn lone_prose_line_between_short_runs_preserved() {
+        let mut s = String::new();
+        s.push_str(&pad_log(MIN_COMPACT_BYTES + 5_000));
+        s.push_str("여기 왜 이런거야?\n");
+        s.push_str(&pad_log(5_000));
+        let out = compact_log_like(&s);
+        assert!(out.contains("여기 왜 이런거야?"));
+    }
+}

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod anthropic;
 pub mod codex_exec;
+pub mod compaction;
 pub mod insight;
 pub mod openai;
 pub mod planner;

--- a/src/analyzer/prompt.rs
+++ b/src/analyzer/prompt.rs
@@ -54,28 +54,6 @@ fn extract_conversation_text(entries: &[LogEntry]) -> String {
     output
 }
 
-/// Recursively collects all non-empty string leaves from JSON.
-fn collect_json_string_leaves(value: &serde_json::Value, out: &mut Vec<String>) {
-    match value {
-        serde_json::Value::String(s) => {
-            if !s.trim().is_empty() {
-                out.push(s.clone());
-            }
-        }
-        serde_json::Value::Array(items) => {
-            for item in items {
-                collect_json_string_leaves(item, out);
-            }
-        }
-        serde_json::Value::Object(map) => {
-            for value in map.values() {
-                collect_json_string_leaves(value, out);
-            }
-        }
-        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
-    }
-}
-
 fn join_unique_lines(parts: &[String]) -> String {
     let mut seen = std::collections::HashSet::new();
     let mut lines = Vec::new();
@@ -91,13 +69,49 @@ fn join_unique_lines(parts: &[String]) -> String {
     lines.join("\n")
 }
 
-fn extract_all_json_text(value: &serde_json::Value) -> String {
-    let mut parts = Vec::new();
-    collect_json_string_leaves(value, &mut parts);
-    join_unique_lines(&parts)
+/// Extracts user-visible text from a Claude user message payload, skipping
+/// `tool_result` blocks (bulk machine output). Kept separate from
+/// `extract_all_json_text` so we don't accidentally leak tool-result bodies
+/// into the analysis prompt.
+fn extract_user_message_text(message: &serde_json::Value) -> String {
+    let Some(content) = message.get("content") else {
+        return String::new();
+    };
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    let Some(blocks) = content.as_array() else {
+        return String::new();
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for block in blocks {
+        let Some(block_type) = block.get("type").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        match block_type {
+            "text" => {
+                if let Some(text) = block.get("text").and_then(serde_json::Value::as_str)
+                    && !text.is_empty()
+                {
+                    parts.push(text.to_string());
+                }
+            }
+            // Keep a marker so the model knows a tool was used without seeing
+            // the payload.
+            "tool_result" => parts.push("[tool_result]".to_string()),
+            _ => {}
+        }
+    }
+    parts.join("\n")
 }
 
 fn extract_assistant_text(blocks: &[ContentBlock]) -> String {
+    // Content policy matches the Codex side:
+    //   - Text / Thinking: keep as-is (insight material).
+    //   - ToolUse: keep only the tool name as a marker — the input payload is
+    //     dropped because it rarely adds insight and balloons the prompt.
+    //   - ToolResult: dropped entirely — bulk machine output; the next
+    //     assistant/user turn usually paraphrases what mattered.
     let mut parts = Vec::new();
     for block in blocks {
         match block {
@@ -111,29 +125,14 @@ fn extract_assistant_text(blocks: &[ContentBlock]) -> String {
                     parts.push(thinking.clone());
                 }
             }
-            ContentBlock::ToolUse { name, id, input } => {
-                if let Some(name) = name {
-                    parts.push(name.clone());
-                }
-                if let Some(id) = id {
-                    parts.push(id.clone());
-                }
-                if let Some(input) = input {
-                    let text = extract_all_json_text(input);
-                    if !text.is_empty() {
-                        parts.push(text);
-                    }
+            ContentBlock::ToolUse { name, .. } => {
+                if let Some(name) = name
+                    && !name.is_empty()
+                {
+                    parts.push(format!("[tool: {name}]"));
                 }
             }
-            ContentBlock::ToolResult { content } => {
-                if let Some(content) = content {
-                    let text = extract_all_json_text(content);
-                    if !text.is_empty() {
-                        parts.push(text);
-                    }
-                }
-            }
-            ContentBlock::Unknown => {}
+            ContentBlock::ToolResult { .. } | ContentBlock::Unknown => {}
         }
     }
     join_unique_lines(&parts)
@@ -158,11 +157,11 @@ fn entry_session_id(entry: &LogEntry) -> Option<&str> {
 }
 
 fn extract_entry_text(entry: &LogEntry) -> Option<(&'static str, String)> {
-    match entry {
+    let (role, text) = match entry {
         LogEntry::User(e) => {
             let mut parts = Vec::new();
             if let Some(message) = &e.message {
-                parts.push(extract_all_json_text(message));
+                parts.push(extract_user_message_text(message));
             }
             if let Some(entrypoint) = &e.entrypoint {
                 parts.push(entrypoint.clone());
@@ -170,8 +169,7 @@ fn extract_entry_text(entry: &LogEntry) -> Option<(&'static str, String)> {
             if let Some(cwd) = &e.cwd {
                 parts.push(cwd.clone());
             }
-            let text = join_unique_lines(&parts);
-            (!text.is_empty()).then_some(("USER", text))
+            ("USER", join_unique_lines(&parts))
         }
         LogEntry::Assistant(e) => {
             let mut parts = Vec::new();
@@ -187,8 +185,7 @@ fn extract_entry_text(entry: &LogEntry) -> Option<(&'static str, String)> {
             if let Some(cwd) = &e.cwd {
                 parts.push(cwd.clone());
             }
-            let text = join_unique_lines(&parts);
-            (!text.is_empty()).then_some(("ASSISTANT", text))
+            ("ASSISTANT", join_unique_lines(&parts))
         }
         LogEntry::Progress(e) => {
             let mut parts = Vec::new();
@@ -198,19 +195,32 @@ fn extract_entry_text(entry: &LogEntry) -> Option<(&'static str, String)> {
             if let Some(cwd) = &e.cwd {
                 parts.push(cwd.clone());
             }
-            let text = join_unique_lines(&parts);
-            (!text.is_empty()).then_some(("PROGRESS", text))
+            ("PROGRESS", join_unique_lines(&parts))
         }
-        LogEntry::System(_) => None,
-        LogEntry::FileHistorySnapshot(e) => e
-            .message_id
-            .as_ref()
-            .and_then(|id| (!id.trim().is_empty()).then_some(("SNAPSHOT", id.clone()))),
+        LogEntry::System(_) => return None,
+        LogEntry::FileHistorySnapshot(e) => {
+            let id = e.message_id.as_ref()?;
+            if id.trim().is_empty() {
+                return None;
+            }
+            ("SNAPSHOT", id.clone())
+        }
         LogEntry::Other(raw) => {
-            let text = extract_all_json_text(raw);
-            (!text.is_empty()).then_some(("EVENT", text))
+            // Unknown Claude log entry types (hook events, background
+            // notifications, ...). Keep only the type marker so the prompt
+            // records that something happened without dumping the payload.
+            let event_type = raw
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
+            ("EVENT", format!("[{event_type}]"))
         }
+    };
+
+    if text.is_empty() {
+        return None;
     }
+    Some((role, super::compaction::compact_log_like(&text)))
 }
 
 /// Extracts (role, text) tuples from LogEntries.
@@ -227,6 +237,7 @@ pub fn extract_messages(entries: &[LogEntry]) -> Vec<(String, String)> {
 
 /// Converts Codex entries into prompt text for LLM analysis.
 /// Each Codex file is a single session, so session_id is passed externally.
+/// Long log-like pastes are compacted to keep the prompt under LLM limits.
 pub fn build_codex_prompt(
     entries: &[CodexEntry],
     session_id: &str,
@@ -234,32 +245,16 @@ pub fn build_codex_prompt(
     let mut output = format!("[Session: {session_id}]\n");
     let mut has_text = false;
 
-    for entry in entries {
-        match entry {
-            CodexEntry::SessionMeta { text, .. } if !text.is_empty() => {
-                has_text = true;
-                output.push_str(&format!("[META] {text}\n"));
-            }
-            CodexEntry::UserMessage { text, .. } if !text.is_empty() => {
-                has_text = true;
-                output.push_str(&format!("[USER] {text}\n"));
-            }
-            CodexEntry::AssistantMessage { text, .. } if !text.is_empty() => {
-                has_text = true;
-                output.push_str(&format!("[ASSISTANT] {text}\n"));
-            }
-            CodexEntry::FunctionCall { text, .. } if !text.is_empty() => {
-                has_text = true;
-                output.push_str(&format!("[TOOL] {text}\n"));
-            }
-            CodexEntry::Other {
-                entry_type, text, ..
-            } if !text.is_empty() => {
-                has_text = true;
-                output.push_str(&format!("[EVENT:{entry_type}] {text}\n"));
-            }
-            _ => {}
+    for (role, text) in codex_role_text_pairs(entries) {
+        has_text = true;
+        output.push('[');
+        output.push_str(&role);
+        output.push(']');
+        if !text.is_empty() {
+            output.push(' ');
+            output.push_str(&text);
         }
+        output.push('\n');
     }
 
     if !has_text {
@@ -269,32 +264,43 @@ pub fn build_codex_prompt(
     Ok(output)
 }
 
-/// Extracts (role, text) tuples from Codex entries.
+/// Extracts (role, text) tuples from Codex entries with log-like pastes compacted.
 pub fn extract_codex_messages(entries: &[CodexEntry]) -> Vec<(String, String)> {
-    let mut messages = Vec::new();
-    for entry in entries {
-        match entry {
-            CodexEntry::SessionMeta { text, .. } if !text.is_empty() => {
-                messages.push(("META".to_string(), text.clone()));
-            }
-            CodexEntry::UserMessage { text, .. } if !text.is_empty() => {
-                messages.push(("USER".to_string(), text.clone()));
-            }
-            CodexEntry::AssistantMessage { text, .. } if !text.is_empty() => {
-                messages.push(("ASSISTANT".to_string(), text.clone()));
-            }
-            CodexEntry::FunctionCall { text, .. } if !text.is_empty() => {
-                messages.push(("TOOL".to_string(), text.clone()));
-            }
-            CodexEntry::Other {
-                entry_type, text, ..
-            } if !text.is_empty() => {
-                messages.push((format!("EVENT:{entry_type}"), text.clone()));
-            }
-            _ => {}
+    codex_role_text_pairs(entries).collect()
+}
+
+fn codex_role_text_pairs(
+    entries: &[CodexEntry],
+) -> impl Iterator<Item = (String, String)> + '_ {
+    // Prompt policy:
+    //   - USER / ASSISTANT messages keep full (compacted) text: they are the
+    //     core material for insight extraction.
+    //   - FunctionCall keeps only the tool name; the raw payload is dropped
+    //     because tool outputs rarely add insight yet balloon prompt size.
+    //   - Other (event_msg, response_item/function_call_output, mcp_tool_call_end,
+    //     exec_command_end, reasoning, ...) keeps only the entry_type marker so
+    //     the model can still see that the session used tools, without
+    //     shipping megabytes of tool-output text through the LLM call.
+    //   - SessionMeta is preserved as-is (short by construction).
+    entries.iter().filter_map(|entry| match entry {
+        CodexEntry::SessionMeta { text, .. } if !text.is_empty() => {
+            Some(("META".to_string(), super::compaction::compact_log_like(text)))
         }
-    }
-    messages
+        CodexEntry::UserMessage { text, .. } if !text.is_empty() => {
+            Some(("USER".to_string(), super::compaction::compact_log_like(text)))
+        }
+        CodexEntry::AssistantMessage { text, .. } if !text.is_empty() => Some((
+            "ASSISTANT".to_string(),
+            super::compaction::compact_log_like(text),
+        )),
+        CodexEntry::FunctionCall { name, .. } if !name.is_empty() => {
+            Some(("TOOL".to_string(), name.clone()))
+        }
+        CodexEntry::Other { entry_type, .. } if !entry_type.is_empty() => {
+            Some((format!("EVENT:{entry_type}"), String::new()))
+        }
+        _ => None,
+    })
 }
 
 /// Extracts unique session IDs from LogEntries, preserving insertion order.
@@ -407,6 +413,56 @@ mod tests {
     }
 
     #[test]
+    fn test_build_prompt_assistant_tool_use_keeps_name_drops_input() {
+        let entries = vec![serde_json::from_str::<LogEntry>(
+            r#"{"type":"assistant","sessionId":"s1","timestamp":"2026-03-11T10:00:30Z","uuid":"a1","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_1","name":"Grep","input":{"pattern":"SECRET_INTERNAL_MARKER","glob":"**/*.rs"}}]}}"#,
+        )
+        .unwrap()];
+        let prompt = build_prompt(&entries).unwrap();
+        assert!(prompt.contains("[tool: Grep]"), "expected tool name marker");
+        assert!(
+            !prompt.contains("SECRET_INTERNAL_MARKER"),
+            "tool_use input must NOT leak into prompt, got:\n{prompt}"
+        );
+        assert!(!prompt.contains("tool_1"), "tool id must not leak either");
+    }
+
+    #[test]
+    fn test_build_prompt_assistant_tool_result_fully_dropped() {
+        let entries = vec![serde_json::from_str::<LogEntry>(
+            r#"{"type":"assistant","sessionId":"s1","timestamp":"2026-03-11T10:00:30Z","uuid":"a1","message":{"role":"assistant","content":[{"type":"tool_result","content":"HUGE_MACHINE_OUTPUT_SHOULD_NOT_APPEAR"}]}}"#,
+        )
+        .unwrap()];
+        // An assistant entry with ONLY a tool_result should produce no USER/
+        // ASSISTANT line at all.
+        let result = build_prompt(&entries);
+        assert!(result.is_err(), "empty-after-filter must surface as error");
+    }
+
+    #[test]
+    fn test_build_prompt_user_tool_result_block_dropped_from_content() {
+        let entries = vec![serde_json::from_str::<LogEntry>(
+            r#"{"type":"user","sessionId":"s1","timestamp":"2026-03-11T10:00:00Z","uuid":"u1","message":{"role":"user","content":[{"type":"text","text":"여기 결과 봐줘"},{"type":"tool_result","tool_use_id":"t1","content":"DO_NOT_LEAK_THIS_BLOB"}]}}"#,
+        )
+        .unwrap()];
+        let prompt = build_prompt(&entries).unwrap();
+        assert!(prompt.contains("여기 결과 봐줘"));
+        assert!(prompt.contains("[tool_result]"));
+        assert!(!prompt.contains("DO_NOT_LEAK_THIS_BLOB"));
+    }
+
+    #[test]
+    fn test_build_prompt_other_kept_as_type_marker_only() {
+        let entries = vec![serde_json::from_str::<LogEntry>(
+            r#"{"type":"hook_event","sessionId":"s1","payload":{"big_body":"PAYLOAD_SHOULD_BE_DROPPED"}}"#,
+        )
+        .unwrap()];
+        let prompt = build_prompt(&entries).unwrap();
+        assert!(prompt.contains("[EVENT] [hook_event]"));
+        assert!(!prompt.contains("PAYLOAD_SHOULD_BE_DROPPED"));
+    }
+
+    #[test]
     fn test_build_prompt_empty_entries_returns_error() {
         let entries: Vec<LogEntry> = vec![];
         let result = build_prompt(&entries);
@@ -450,7 +506,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_codex_messages_includes_metadata_and_tool_entries() {
+    fn test_extract_codex_messages_drops_tool_body_and_other_body() {
         use crate::parser::codex::CodexEntry;
         let entries = vec![
             CodexEntry::SessionMeta {
@@ -471,7 +527,12 @@ mod tests {
             CodexEntry::FunctionCall {
                 timestamp: "2026-03-11T10:00:20Z".parse().unwrap(),
                 name: "Read".to_string(),
-                text: "Read\nsrc/main.rs".to_string(),
+                text: "Read\nsrc/main.rs\n...giant file content...".to_string(),
+            },
+            CodexEntry::Other {
+                timestamp: "2026-03-11T10:00:30Z".parse().unwrap(),
+                entry_type: "response_item/function_call_output".to_string(),
+                text: "huge multi-megabyte payload that must be dropped".to_string(),
             },
         ];
         let messages = extract_codex_messages(&entries);
@@ -481,9 +542,46 @@ mod tests {
                 ("META".to_string(), "s1\n/tmp\nopenai".to_string()),
                 ("USER".to_string(), "질문".to_string()),
                 ("ASSISTANT".to_string(), "답변".to_string()),
-                ("TOOL".to_string(), "Read\nsrc/main.rs".to_string())
+                ("TOOL".to_string(), "Read".to_string()),
+                (
+                    "EVENT:response_item/function_call_output".to_string(),
+                    String::new(),
+                ),
             ]
         );
+    }
+
+    #[test]
+    fn test_build_codex_prompt_omits_tool_and_event_bodies() {
+        use crate::parser::codex::CodexEntry;
+        let entries = vec![
+            CodexEntry::UserMessage {
+                timestamp: "2026-03-11T10:00:00Z".parse().unwrap(),
+                text: "리뷰해줘".to_string(),
+            },
+            CodexEntry::FunctionCall {
+                timestamp: "2026-03-11T10:00:05Z".parse().unwrap(),
+                name: "Grep".to_string(),
+                text: "Grep\n... huge args ...".to_string(),
+            },
+            CodexEntry::Other {
+                timestamp: "2026-03-11T10:00:06Z".parse().unwrap(),
+                entry_type: "event_msg/mcp_tool_call_end".to_string(),
+                text: "... multi-MB tool result ...".to_string(),
+            },
+            CodexEntry::AssistantMessage {
+                timestamp: "2026-03-11T10:00:10Z".parse().unwrap(),
+                text: "완료".to_string(),
+            },
+        ];
+        let prompt = build_codex_prompt(&entries, "s1").unwrap();
+        assert!(prompt.contains("[USER] 리뷰해줘"));
+        assert!(prompt.contains("[TOOL] Grep"));
+        assert!(prompt.contains("[EVENT:event_msg/mcp_tool_call_end]\n"));
+        assert!(prompt.contains("[ASSISTANT] 완료"));
+        // Must NOT leak the dropped bodies.
+        assert!(!prompt.contains("huge args"));
+        assert!(!prompt.contains("multi-MB tool result"));
     }
 
     #[test]

--- a/src/analyzer/summarizer.rs
+++ b/src/analyzer/summarizer.rs
@@ -8,6 +8,11 @@ use super::prompt::estimate_tokens;
 
 use crate::config::Lang;
 
+/// Safety cap on the number of chunk-summarize API calls we make for a single
+/// session. A pathological session that still explodes into dozens of chunks
+/// after compaction would otherwise burn through the provider's daily quota.
+pub const MAX_CHUNKS_PER_SESSION: usize = 3;
+
 const CHUNK_SUMMARIZE_PROMPT_EN: &str = include_str!("../../prompts/chunk_summarize_en.md");
 const CHUNK_SUMMARIZE_PROMPT_KO: &str = include_str!("../../prompts/chunk_summarize_ko.md");
 
@@ -116,10 +121,20 @@ pub async fn summarize_chunks(
     limits: &RateLimits,
     lang: &Lang,
 ) -> Result<String, super::AnalyzerError> {
-    let mut summaries: Vec<String> = Vec::new();
-    let total = chunks.len();
+    let effective_chunks: &[Vec<(String, String)>] = if chunks.len() > MAX_CHUNKS_PER_SESSION {
+        eprintln!(
+            "{}",
+            crate::messages::status::chunk_cap_applied(chunks.len(), MAX_CHUNKS_PER_SESSION)
+        );
+        &chunks[..MAX_CHUNKS_PER_SESSION]
+    } else {
+        chunks
+    };
 
-    for (i, chunk) in chunks.iter().enumerate() {
+    let mut summaries: Vec<String> = Vec::new();
+    let total = effective_chunks.len();
+
+    for (i, chunk) in effective_chunks.iter().enumerate() {
         let chunk_text: String = chunk
             .iter()
             .map(|(role, text)| format!("[{role}] {text}"))
@@ -215,4 +230,5 @@ mod tests {
         let wait = calculate_wait(100, &limits);
         assert!((wait - 1.2).abs() < 0.1);
     }
+
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -348,6 +348,12 @@ pub mod status {
         format!("    \u{2713} Chunk {i}/{total} done")
     }
 
+    pub fn chunk_cap_applied(requested: usize, cap: usize) -> String {
+        format!(
+            "    \u{26A0} Session produced {requested} chunks; capping to first {cap} to preserve quota"
+        )
+    }
+
     pub fn plan_multi_step_scoped(source: &str, steps: usize, total_tokens: u64) -> String {
         format!("\u{2713} [{source}] Analyzing {steps} sessions (est. {total_tokens} tokens)")
     }


### PR DESCRIPTION
## Summary
- `rwd today` 분석에서 세션 prompt 크기를 폭발시키던 두 가지 원인을 구조적으로 제거해 chunk 분할을 사실상 없앰.
- **Claude 11,961 KB → 709 KB (-94%)**, **Codex 36,649 KB → 2,550 KB (-93%)** (2026-04-17 세션 기준 실측).
- 이전에 usage limit에 부딪히거나 한 세션이 19 chunks로 쪼개지던 케이스가 모두 Direct 1회 호출로 처리됨.

## 변경 내용

### 1. Tool 본문 / 이벤트 payload를 prompt에서 제외 (본 작업의 핵심)

Codex (`build_codex_prompt` / `extract_codex_messages`):
- `CodexEntry::FunctionCall` → `[TOOL] {name}` 마커만, payload_text drop
- `CodexEntry::Other` (function_call_output, mcp_tool_call_end, exec_command_end, reasoning 등) → `[EVENT:entry_type]` 마커만, 본문 drop
- USER / ASSISTANT / SessionMeta는 기존대로 유지 (compaction만 적용)

Claude (`extract_assistant_text` / `extract_user_message_text` / `LogEntry::Other`):
- `ContentBlock::ToolUse` → `[tool: name]` 마커만, input drop
- `ContentBlock::ToolResult` → 완전 drop
- User message의 `tool_result` 블록 → `[tool_result]` 마커만, content drop
- `LogEntry::Other` → `[{type}]` 마커만, payload drop

### 2. 블록 단위 log compaction (`src/analyzer/compaction.rs` 신규)

메시지 안에서 로그성 라인이 연속된 구간만 축약해 사용자의 자연어(질문/설명)는 100% 보존:
- 줄별 `Log` / `Prose` / `Neutral` 분류 (ANSI, stack trace, timestamp, shell/error 프리픽스, 반복되는 8-byte 라인 프리픽스 + 낮은 문장 종결 밀도)
- 연속 Log run이 20줄 & 2 KB 이상일 때만 앞 5줄 + `… [N log-like lines, M bytes omitted] …` + 뒤 3줄로 축약
- 결과가 원본보다 커지면 원본 반환

### 3. Chunk 상한 (`MAX_CHUNKS_PER_SESSION = 3`)

compaction 후에도 혹시 거대해지는 병적 세션에 대비해 `summarize_chunks` 진입 시 chunk 수를 3으로 절단하고 `messages::status::chunk_cap_applied` 경고 출력.

## 엣지 케이스 방어 (compaction 테스트에 포함)

빈 입력 · 임계 미만 · 개행 없는 단일 라인 · 전부 prose · 전부 log · prose 사이 로그 · 로그 사이 prose · 다중 교차 · 짧은 run 보존 · Windows \\r\\n · trailing newline 보존 · UTF-8 한글 경계 · 버전 번호(`v1.0.106`)의 prose 오탐 방지 · 마크다운 펜스/구분선 Neutral · compaction 후 결과 크기 성장 방지.

## Test plan
- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] `cargo test` — 208 passed (prompt 5개 + compaction 27개 신규)
- [x] `cargo run --release -- today --no-cache --date 2026-04-17` 실제 실행으로 검증: Claude 17 + Codex 9 세션 모두 chunk 분할 없이 Direct 호출로 완료, 산출된 insight markdown 정상 생성