### PR TITLE
feat: filter codex subagent sessions by metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ include_automated = true
 ```
 - Keep custom Claude roots in either legacy `[input] claude_roots = [...]` or new `[input.claude] roots = [...]`.
 
+Codex session filtering:
+- Default behavior excludes sessions with explicit subagent metadata in `session_meta`.
+- Hard signals are `source.subagent`, `agent_role`, and `agent_nickname`.
+- Worktree interactive sessions are still included by default.
+- `cwd` patterns and prompt heuristics are not used.
+
 ## Release policy (maintainers)
 
 - Release is triggered automatically on `main` push only when these files changed:

--- a/docs/superpowers/plans/2026-04-22-codex-subagent-session-filtering.md
+++ b/docs/superpowers/plans/2026-04-22-codex-subagent-session-filtering.md
@@ -1,0 +1,501 @@
+# Codex Subagent Session Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `session_meta`에 명시된 hard signal만 사용해 Codex subagent 세션을 기본 제외하고, 일반 interactive 세션과 worktree 기반 interactive 세션은 그대로 포함한다.
+
+**Architecture:** `src/parser/codex.rs`의 `CodexEntry::SessionMeta`에 `source.subagent`, `agent_role`, `agent_nickname`를 보존하는 최소 확장을 추가한다. 그 뒤 parsed entries만 보고 `CodexSessionKind`를 판별하는 helper를 만들고, `src/main.rs`의 `collect_codex_sessions()`에서 merge 전에 `Subagent`만 early-continue로 제외한다. README에는 Claude와 별도로 Codex 기본 필터링 정책을 문서화한다.
+
+**Tech Stack:** Rust 2024, serde_json, chrono, cargo build, cargo clippy, cargo test
+
+---
+
+## File Structure
+
+| File | Change | Role |
+|------|--------|------|
+| `src/parser/codex.rs` | Modify | `SessionMeta` 확장, hard-signal 추출 helper, `CodexSessionKind` 분류 helper, parser/unit tests |
+| `src/main.rs` | Modify | `collect_codex_sessions()`에서 Codex subagent 기본 제외, collection tests |
+| `src/analyzer/prompt.rs` | Modify | 확장된 `CodexEntry::SessionMeta` 테스트 fixture 컴파일 유지 |
+| `README.md` | Modify | Codex session filtering 기본 동작 문서화 |
+
+**Behavior change:** Codex rollout JSONL 중 `session_meta`에 `source.subagent`, `agent_role`, `agent_nickname` 중 하나라도 명시된 세션은 기본적으로 수집에서 제외된다. `cwd`가 `~/.codex/worktrees/...`라는 사실만으로는 제외하지 않는다.
+
+### Task 1: Parser hard-signal tests first
+
+**Files:**
+- Modify: `src/parser/codex.rs:484-862`
+
+- [ ] **Step 1: `session_meta`가 explicit subagent metadata를 보존하는 테스트 추가**
+
+`src/parser/codex.rs`의 기존 parser tests 바로 아래에 다음 테스트를 추가한다.
+
+```rust
+#[test]
+fn test_parse_session_meta_entry_preserves_subagent_metadata() {
+    let json = r#"{"timestamp":"2026-04-22T09:00:00Z","type":"session_meta","payload":{"id":"sess-sub","cwd":"/Users/jinwoohan/.codex/memories","model_provider":"openai","source":{"subagent":"memory_consolidation"},"agent_role":"memory builder","agent_nickname":"Morpheus"}}"#;
+    let raw: CodexRawEntry = serde_json::from_str(json).unwrap();
+    let entry = CodexEntry::from_raw(raw);
+
+    if let CodexEntry::SessionMeta {
+        session_id,
+        cwd,
+        model_provider,
+        subagent_source,
+        agent_role,
+        agent_nickname,
+        ..
+    } = entry
+    {
+        assert_eq!(session_id, "sess-sub");
+        assert_eq!(cwd, "/Users/jinwoohan/.codex/memories");
+        assert_eq!(model_provider, "openai");
+        assert_eq!(subagent_source.as_deref(), Some("memory_consolidation"));
+        assert_eq!(agent_role.as_deref(), Some("memory builder"));
+        assert_eq!(agent_nickname.as_deref(), Some("Morpheus"));
+    } else {
+        panic!("Expected SessionMeta variant");
+    }
+}
+```
+
+- [ ] **Step 2: 문자열 `source`는 hard signal로 취급하지 않는 테스트 추가**
+
+```rust
+#[test]
+fn test_parse_session_meta_entry_ignores_string_source_for_subagent_detection() {
+    let json = r#"{"timestamp":"2026-04-22T09:00:00Z","type":"session_meta","payload":{"id":"sess-cli","cwd":"/Users/jinwoohan/workspace/repos/personal/rwd","model_provider":"openai","source":"cli"}}"#;
+    let raw: CodexRawEntry = serde_json::from_str(json).unwrap();
+    let entry = CodexEntry::from_raw(raw);
+
+    if let CodexEntry::SessionMeta {
+        subagent_source,
+        agent_role,
+        agent_nickname,
+        ..
+    } = entry
+    {
+        assert_eq!(subagent_source, None);
+        assert_eq!(agent_role, None);
+        assert_eq!(agent_nickname, None);
+    } else {
+        panic!("Expected SessionMeta variant");
+    }
+}
+```
+
+- [ ] **Step 3: `CodexSessionKind` 분류 규칙 테스트 추가**
+
+```rust
+#[test]
+fn test_classify_codex_session_kind_uses_only_explicit_metadata() {
+    use chrono::TimeZone;
+    let ts = chrono::Utc.with_ymd_and_hms(2026, 4, 22, 9, 0, 0).unwrap();
+
+    let interactive = vec![CodexEntry::SessionMeta {
+        timestamp: ts,
+        session_id: "interactive".to_string(),
+        cwd: "/Users/jinwoohan/.codex/worktrees/1234/rwd".to_string(),
+        model_provider: "openai".to_string(),
+        subagent_source: None,
+        agent_role: None,
+        agent_nickname: None,
+        text: "interactive".to_string(),
+    }];
+    assert_eq!(
+        classify_codex_session(&interactive),
+        CodexSessionKind::Interactive
+    );
+
+    let by_source = vec![CodexEntry::SessionMeta {
+        timestamp: ts,
+        session_id: "subagent-source".to_string(),
+        cwd: "/Users/jinwoohan/.codex/memories".to_string(),
+        model_provider: "openai".to_string(),
+        subagent_source: Some("memory_consolidation".to_string()),
+        agent_role: None,
+        agent_nickname: None,
+        text: "subagent".to_string(),
+    }];
+    assert_eq!(
+        classify_codex_session(&by_source),
+        CodexSessionKind::Subagent
+    );
+
+    let by_role = vec![CodexEntry::SessionMeta {
+        timestamp: ts,
+        session_id: "subagent-role".to_string(),
+        cwd: "/Users/jinwoohan/.codex/memories".to_string(),
+        model_provider: "openai".to_string(),
+        subagent_source: None,
+        agent_role: Some("memory builder".to_string()),
+        agent_nickname: None,
+        text: "subagent".to_string(),
+    }];
+    assert_eq!(
+        classify_codex_session(&by_role),
+        CodexSessionKind::Subagent
+    );
+
+    let by_nickname = vec![CodexEntry::SessionMeta {
+        timestamp: ts,
+        session_id: "subagent-nickname".to_string(),
+        cwd: "/Users/jinwoohan/.codex/memories".to_string(),
+        model_provider: "openai".to_string(),
+        subagent_source: None,
+        agent_role: None,
+        agent_nickname: Some("Morpheus".to_string()),
+        text: "subagent".to_string(),
+    }];
+    assert_eq!(
+        classify_codex_session(&by_nickname),
+        CodexSessionKind::Subagent
+    );
+}
+```
+
+- [ ] **Step 4: 새 parser tests가 현재 코드에서 실패하는지 확인**
+
+Run: `cargo test test_parse_session_meta_entry_preserves_subagent_metadata -- --exact`
+Expected: FAIL with compile errors for missing `subagent_source`, `agent_role`, `agent_nickname`, `CodexSessionKind`, or `classify_codex_session`
+
+### Task 2: Extend `SessionMeta` and add the classification helper
+
+**Files:**
+- Modify: `src/parser/codex.rs:35-170`
+- Modify: `src/parser/codex.rs:336-482`
+- Modify: `src/parser/codex.rs:653-861`
+- Modify: `src/main.rs:1551-1569`
+- Modify: `src/analyzer/prompt.rs:512-518`
+
+- [ ] **Step 1: `CodexEntry::SessionMeta`와 `CodexSessionKind` 정의 확장**
+
+`src/parser/codex.rs`의 enum definitions를 다음 형태로 업데이트한다.
+
+```rust
+#[derive(Debug)]
+pub enum CodexEntry {
+    SessionMeta {
+        timestamp: DateTime<Utc>,
+        session_id: String,
+        cwd: String,
+        model_provider: String,
+        subagent_source: Option<String>,
+        agent_role: Option<String>,
+        agent_nickname: Option<String>,
+        text: String,
+    },
+    UserMessage {
+        timestamp: DateTime<Utc>,
+        text: String,
+    },
+    AssistantMessage {
+        timestamp: DateTime<Utc>,
+        text: String,
+    },
+    FunctionCall {
+        timestamp: DateTime<Utc>,
+        name: String,
+        text: String,
+    },
+    Other {
+        timestamp: DateTime<Utc>,
+        entry_type: String,
+        text: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexSessionKind {
+    Interactive,
+    Subagent,
+}
+```
+
+- [ ] **Step 2: hard-signal extraction helper와 `from_raw()` parsing 추가**
+
+`src/parser/codex.rs`의 `extract_payload_text()` 아래에 helper를 추가하고, `session_meta` branch를 교체한다.
+
+```rust
+fn optional_non_empty_string(value: &serde_json::Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn extract_subagent_source(payload: &serde_json::Value) -> Option<String> {
+    payload
+        .get("source")
+        .and_then(|value| value.as_object())
+        .and_then(|source| source.get("subagent"))
+        .and_then(optional_non_empty_string)
+}
+
+pub fn classify_codex_session(entries: &[CodexEntry]) -> CodexSessionKind {
+    for entry in entries {
+        if let CodexEntry::SessionMeta {
+            subagent_source,
+            agent_role,
+            agent_nickname,
+            ..
+        } = entry
+        {
+            if subagent_source.is_some() || agent_role.is_some() || agent_nickname.is_some() {
+                return CodexSessionKind::Subagent;
+            }
+        }
+    }
+
+    CodexSessionKind::Interactive
+}
+```
+
+`from_raw()`의 `session_meta` branch는 다음 형태로 바꾼다.
+
+```rust
+"session_meta" => {
+    let session_id = payload["id"].as_str().unwrap_or_default().to_string();
+    let cwd = payload["cwd"].as_str().unwrap_or_default().to_string();
+    let model_provider = payload["model_provider"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    let subagent_source = extract_subagent_source(payload);
+    let agent_role = payload
+        .get("agent_role")
+        .and_then(optional_non_empty_string);
+    let agent_nickname = payload
+        .get("agent_nickname")
+        .and_then(optional_non_empty_string);
+
+    CodexEntry::SessionMeta {
+        timestamp: ts,
+        session_id,
+        cwd,
+        model_provider,
+        subagent_source,
+        agent_role,
+        agent_nickname,
+        text: payload_text.clone(),
+    }
+}
+```
+
+- [ ] **Step 3: fingerprint와 수동 `SessionMeta` fixtures를 expanded shape로 맞추기**
+
+`src/parser/codex.rs`의 `CodexEntryFingerprint::SessionMeta`와 `entry_fingerprint()`에 아래 필드를 추가한다.
+
+```rust
+SessionMeta {
+    timestamp_millis: i64,
+    session_id: String,
+    cwd: String,
+    model_provider: String,
+    subagent_source: Option<String>,
+    agent_role: Option<String>,
+    agent_nickname: Option<String>,
+    text: String,
+},
+```
+
+그리고 `CodexEntry::SessionMeta`를 수동으로 만드는 모든 테스트 fixture를 다음 shape로 맞춘다.
+
+```rust
+CodexEntry::SessionMeta {
+    timestamp: ts,
+    session_id: "s1".to_string(),
+    cwd: "/p".to_string(),
+    model_provider: "openai".to_string(),
+    subagent_source: None,
+    agent_role: None,
+    agent_nickname: None,
+    text: "s1\n/p\nopenai".to_string(),
+}
+```
+
+이 패턴을 아래 위치에 모두 적용한다.
+- `src/parser/codex.rs:658-664`
+- `src/parser/codex.rs:721-727`
+- `src/parser/codex.rs:765-771`
+- `src/parser/codex.rs:791-797`
+- `src/parser/codex.rs:823-829`
+- `src/main.rs:1554-1560`
+- `src/analyzer/prompt.rs:512-518`
+
+- [ ] **Step 4: parser 대상 tests만 먼저 통과시키기**
+
+Run: `cargo test parser::codex::tests:: -- --nocapture`
+Expected: new parsing/classification tests PASS and existing parser tests still PASS
+
+- [ ] **Step 5: parser 단위 커밋**
+
+```bash
+git add src/parser/codex.rs src/main.rs src/analyzer/prompt.rs
+git commit -m "feat: capture codex subagent metadata"
+```
+
+### Task 3: Add collection tests for exclusion and false-positive protection
+
+**Files:**
+- Modify: `src/main.rs:1466-1577`
+
+- [ ] **Step 1: explicit subagent metadata가 있는 세션을 제외하는 collection test 추가**
+
+`src/main.rs` tests module에 다음 테스트를 추가한다.
+
+```rust
+#[test]
+fn test_collect_codex_sessions_excludes_explicit_subagent_sessions() {
+    let date = chrono::NaiveDate::from_ymd_opt(2099, 1, 1).expect("date");
+    let base = unique_temp_dir("rwd_test_codex_subagent_filter");
+    let root = base.join("codex-root");
+    let day_dir = root.join("2099").join("01").join("01");
+    std::fs::create_dir_all(&day_dir).expect("day dir");
+
+    let mut file = std::fs::File::create(day_dir.join("rollout-subagent.jsonl")).expect("file");
+    writeln!(
+        file,
+        r#"{{"timestamp":"2099-01-01T12:00:00Z","type":"session_meta","payload":{{"id":"codex-subagent","cwd":"/Users/jinwoohan/.codex/memories","model_provider":"openai","source":{{"subagent":"memory_consolidation"}},"agent_role":"memory builder","agent_nickname":"Morpheus"}}}}"#
+    )
+    .expect("meta");
+    writeln!(
+        file,
+        r#"{{"timestamp":"2099-01-01T12:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"summarize memories"}}}}"#
+    )
+    .expect("user");
+    writeln!(
+        file,
+        r#"{{"timestamp":"2099-01-01T12:02:00Z","type":"response_item","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"done"}}]}}}}"#
+    )
+    .expect("assistant");
+
+    let cfg = test_config(Some(vec![root.to_string_lossy().to_string()]), None);
+    let (sessions, roots) = collect_codex_sessions(date, Some(&cfg));
+
+    assert_eq!(roots, vec![root.clone()]);
+    assert!(sessions.is_empty());
+
+    std::fs::remove_dir_all(&base).ok();
+}
+```
+
+- [ ] **Step 2: worktree cwd만 있는 interactive session은 유지하는 test 추가**
+
+```rust
+#[test]
+fn test_collect_codex_sessions_keeps_worktree_interactive_sessions_without_hard_signal() {
+    let date = chrono::NaiveDate::from_ymd_opt(2099, 1, 1).expect("date");
+    let base = unique_temp_dir("rwd_test_codex_worktree_interactive");
+    let root = base.join("codex-root");
+    let day_dir = root.join("2099").join("01").join("01");
+    std::fs::create_dir_all(&day_dir).expect("day dir");
+
+    let mut file = std::fs::File::create(day_dir.join("rollout-interactive.jsonl")).expect("file");
+    writeln!(
+        file,
+        r#"{{"timestamp":"2099-01-01T12:00:00Z","type":"session_meta","payload":{{"id":"codex-interactive","cwd":"/Users/jinwoohan/.codex/worktrees/1234/rwd","model_provider":"openai","source":"cli"}}}}"#
+    )
+    .expect("meta");
+    writeln!(
+        file,
+        r#"{{"timestamp":"2099-01-01T12:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"continue the bugfix"}}}}"#
+    )
+    .expect("user");
+    writeln!(
+        file,
+        r#"{{"timestamp":"2099-01-01T12:02:00Z","type":"response_item","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"working on it"}}]}}}}"#
+    )
+    .expect("assistant");
+
+    let cfg = test_config(Some(vec![root.to_string_lossy().to_string()]), None);
+    let (sessions, _) = collect_codex_sessions(date, Some(&cfg));
+
+    assert_eq!(sessions.len(), 1);
+    let (summary, _) = &sessions[0];
+    assert_eq!(summary.session_id, "codex-interactive");
+    assert_eq!(summary.cwd, "/Users/jinwoohan/.codex/worktrees/1234/rwd");
+
+    std::fs::remove_dir_all(&base).ok();
+}
+```
+
+- [ ] **Step 3: 새 collection tests가 현재 코드에서 실패하는지 확인**
+
+Run: `cargo test test_collect_codex_sessions_excludes_explicit_subagent_sessions -- --exact`
+Expected: FAIL because `collect_codex_sessions()` still includes explicit subagent sessions
+
+### Task 4: Filter subagents in `collect_codex_sessions()`, document it, and verify the repo
+
+**Files:**
+- Modify: `src/main.rs:1012-1038`
+- Modify: `README.md:123-130`
+
+- [ ] **Step 1: `collect_codex_sessions()`에 hard-signal subagent early-continue 추가**
+
+`src/main.rs`의 inner file loop를 다음으로 바꾼다.
+
+```rust
+for file in session_files {
+    let Ok(entries) = parser::codex::parse_codex_jsonl_file(&file) else {
+        continue;
+    };
+    let entries = parser::codex::filter_entries_by_local_date(entries, today);
+    let summary = parser::codex::summarize_codex_entries(&entries);
+    if summary.user_count == 0 && summary.assistant_count == 0 {
+        continue;
+    }
+    if parser::codex::classify_codex_session(&entries)
+        == parser::codex::CodexSessionKind::Subagent
+    {
+        continue;
+    }
+
+    let merge_key = if !summary.session_id.is_empty() {
+        SessionMergeKey::SessionId(summary.session_id)
+    } else {
+        let rollout_filename = file
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| file.to_string_lossy().to_string());
+        SessionMergeKey::RootAndFile {
+            root: root.clone(),
+            rollout_filename,
+        }
+    };
+
+    merged_entries.entry(merge_key).or_default().extend(entries);
+}
+```
+
+- [ ] **Step 2: README에 Codex filtering 정책 추가**
+
+`README.md`의 Claude filtering section 바로 아래에 다음 블록을 추가한다.
+
+```md
+Codex session filtering:
+- Default behavior excludes Codex sessions that contain explicit subagent metadata in `session_meta`.
+- Hard signals are `source.subagent`, `agent_role`, and `agent_nickname`.
+- Interactive Codex sessions are still included by default, including sessions launched from `~/.codex/worktrees/...`.
+- `cwd` patterns and prompt heuristics are not used for Codex subagent filtering.
+```
+
+- [ ] **Step 3: 전체 검증 실행**
+
+Run: `cargo build`
+Expected: build succeeds
+
+Run: `cargo clippy`
+Expected: no warnings or errors
+
+Run: `cargo test`
+Expected: all tests PASS, including parser and collection tests for subagent exclusion and worktree false-positive protection
+
+- [ ] **Step 4: 최종 커밋**
+
+```bash
+git add src/parser/codex.rs src/main.rs src/analyzer/prompt.rs README.md docs/superpowers/plans/2026-04-22-codex-subagent-session-filtering.md
+git commit -m "feat: filter codex subagent sessions by metadata"
+```

--- a/docs/superpowers/specs/2026-04-22-codex-subagent-session-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-22-codex-subagent-session-filtering-design.md
@@ -1,0 +1,208 @@
+# Codex Subagent Session Filtering
+
+## Problem
+
+현재 `rwd`의 Codex 수집 로직은 날짜에 해당하는 rollout JSONL 파일을 모두 읽고, 오늘 대화가 있으면 세션으로 포함한다.
+
+이 구조에는 "Codex 서브에이전트 세션"을 제외하는 단계가 없다.
+
+- `src/main.rs`의 `collect_codex_sessions()`는 날짜 기준으로 rollout 파일을 전부 수집한다.
+- `src/parser/codex.rs`의 `SessionMeta` 파싱은 `id`, `cwd`, `model_provider`만 구조화하고 나머지 메타데이터는 버린다.
+
+결과적으로 서브에이전트가 별도 세션 파일로 저장되더라도, 현재 구현은 그것을 일반 사용자 세션과 구분하지 못한다.
+
+## Validated Observations
+
+이번 설계는 추정이 아니라 실제 로컬 Codex 세션 파일을 확인한 뒤 정리한 사실에 기반한다.
+
+### 1. Worktree 경로만으로는 서브에이전트를 판별할 수 없다
+
+`cwd`가 `~/.codex/worktrees/...`인 세션 2개를 직접 확인했을 때, 두 세션 모두 첫 실제 사용자 메시지가 정상적인 인터랙티브 요청이었다.
+
+즉 다음 규칙은 잘못된 규칙이다.
+
+- `cwd`가 `~/.codex/worktrees/...`이면 서브에이전트로 본다
+
+이번 설계에서는 이 규칙을 사용하지 않는다.
+
+### 2. 실제 서브에이전트 세션에는 hard signal이 존재한다
+
+전체 `session_meta` 스키마를 확인했을 때 대부분의 세션은 일반 필드만 갖고 있었지만, 일부 세션에는 다음 필드가 추가로 존재했다.
+
+- `agent_role`
+- `agent_nickname`
+- `source`가 문자열이 아니라 객체이며, 예: `{"subagent": "memory_consolidation"}`
+
+실제로 확인된 예시는 다음과 같았다.
+
+- `cwd = /Users/jinwoohan/.codex/memories`
+- `agent_role = "memory builder"`
+- `agent_nickname = "Morpheus"`
+- `source = {"subagent": "memory_consolidation"}`
+
+이 조합은 일반 인터랙티브 세션보다 훨씬 강한 서브에이전트 신호다.
+
+## Goal
+
+Codex 세션 파일 안에 이미 존재하는 hard signal만 사용해서 서브에이전트 세션을 기본 제외한다.
+
+핵심 목표는 다음과 같다.
+
+- 일반 인터랙티브 Codex 세션은 계속 포함하기
+- worktree 기반 일반 세션을 잘못 제외하지 않기
+- 세션 파일에서 명시적으로 확인되는 서브에이전트만 제외하기
+
+## Non-Goals
+
+- `cwd` 패턴만으로 서브에이전트를 추정하지 않는다
+- 첫 프롬프트 문구, 말투, 작업 스타일 같은 휴리스틱을 쓰지 않는다
+- Claude의 자동화 세션 필터와 동일한 CLI/config override까지 이번 1차 설계 범위에 포함하지 않는다
+- 부모 세션과 자식 세션을 연결하는 계보 그래프를 만들지 않는다
+
+## Proposed Solution
+
+### 1. SessionMeta에 필요한 메타데이터를 보존한다
+
+현재 `CodexEntry::SessionMeta`는 서브에이전트 판별에 필요한 메타데이터를 잃어버린다.
+
+이를 최소 범위로 확장한다.
+
+```rust
+SessionMeta {
+    timestamp: DateTime<Utc>,
+    session_id: String,
+    cwd: String,
+    model_provider: String,
+    subagent_source: Option<String>,
+    agent_role: Option<String>,
+    agent_nickname: Option<String>,
+    text: String,
+}
+```
+
+파싱 규칙은 다음과 같다.
+
+- `source`가 문자열이면 기존처럼 일반 source로 간주하고 서브에이전트 판정에 사용하지 않는다
+- `source`가 객체이고 `subagent` 문자열을 가지면 `subagent_source = Some(...)`
+- `agent_role`와 `agent_nickname`는 문자열일 때만 채택한다
+
+이 구조는 가장 작은 변경으로 현재 문제를 해결한다.
+
+### 2. Codex 세션 분류를 추가한다
+
+세션 단위로 다음 분류를 도입한다.
+
+```rust
+enum CodexSessionKind {
+    Interactive,
+    Subagent,
+}
+```
+
+분류 규칙은 hard signal만 사용한다.
+
+- `subagent_source.is_some()` 이면 `Subagent`
+- 아니면 `agent_role.is_some()` 이면 `Subagent`
+- 아니면 `agent_nickname.is_some()` 이면 `Subagent`
+- 그 외는 `Interactive`
+
+이 순서의 의미는 "확실한 메타데이터가 있을 때만 제외"다.
+
+### 3. 수집 단계에서 Subagent를 기본 제외한다
+
+`src/main.rs`의 `collect_codex_sessions()`에서:
+
+1. 파일을 읽는다
+2. 날짜 필터를 적용한다
+3. 요약을 만든다
+4. `SessionMeta`를 기반으로 세션 종류를 판별한다
+5. `Subagent`이면 제외한다
+6. `Interactive`만 기존 merge/dedupe 흐름으로 넘긴다
+
+이때 merge key, dedupe, timestamp 정렬 로직은 그대로 유지한다.
+
+즉 이번 변경의 핵심은 "수집 후보를 줄이는 필터 1개 추가"이지, 수집 파이프라인 전체 재설계가 아니다.
+
+## Design Decisions
+
+### Why not filter by worktree cwd?
+
+실제 확인 결과 worktree cwd를 사용하는 일반 인터랙티브 세션이 존재했다.
+
+따라서 worktree 기준 필터는 오탐을 만든다.
+
+### Why not use prompt heuristics?
+
+이번 문제는 이미 세션 파일 안에 메타데이터가 존재하는 경우가 확인되었다.
+
+이럴 때는 말투나 패턴 추정보다 저장된 메타데이터를 우선 사용해야 한다.
+
+### Why not add a general metadata map first?
+
+가능은 하지만 지금 문제를 해결하는 데 필요 이상으로 범위를 키운다.
+
+이번 변경은 Rust 학습자 친화성과 유지보수성을 위해 "필요한 필드만 추가 파싱"하는 쪽을 선택한다.
+
+## Architecture Impact
+
+영향 범위는 작다.
+
+- `src/parser/codex.rs`
+  - `SessionMeta` 필드 확장
+  - `session_meta` 파싱 확장
+  - 세션 종류 판별 helper 추가
+- `src/main.rs`
+  - `collect_codex_sessions()`에서 subagent 제외 로직 추가
+- `README.md`
+  - Codex subagent 기본 제외 동작 문서화
+
+## Error Handling
+
+- `source`가 문자열이 아니고 객체도 아니면 무시한다
+- `source.subagent`가 문자열이 아니면 무시한다
+- `agent_role`, `agent_nickname`가 비문자열이면 무시한다
+- 메타데이터가 일부만 있어도 hard signal이 하나라도 있으면 `Subagent`로 본다
+
+이 규칙은 로그 포맷 변화에 대해 안전한 기본값을 제공한다.
+
+## Test Plan
+
+### Parser
+
+- unit test: `source`가 문자열일 때 `subagent_source`가 비어 있는지
+- unit test: `source = {"subagent":"memory_consolidation"}`일 때 `subagent_source`가 채워지는지
+- unit test: `agent_role`, `agent_nickname`가 있으면 `SessionMeta`에 보존되는지
+
+### Classification
+
+- unit test: `subagent_source`가 있으면 `Subagent`
+- unit test: `agent_role`만 있어도 `Subagent`
+- unit test: `agent_nickname`만 있어도 `Subagent`
+- unit test: 세 필드가 모두 없으면 `Interactive`
+
+### Collection
+
+- unit test: 일반 인터랙티브 Codex 세션은 계속 수집되는지
+- unit test: `source.subagent`가 있는 세션은 제외되는지
+- unit test: `cwd`가 `~/.codex/worktrees/...`라도 hard signal이 없으면 포함되는지
+
+### Verification
+
+- `cargo build`
+- `cargo clippy`
+- `cargo test`
+
+## Migration Notes
+
+- 기존 캐시 포맷 변경은 필요 없다
+- 기존 사용자 설정 변경은 필요 없다
+- 동작 변화는 "일부 Codex subagent 세션이 기본 제외됨" 한 가지다
+
+## Recommended First Implementation Slice
+
+1. `SessionMeta`에 `subagent_source`, `agent_role`, `agent_nickname` 추가
+2. `session_meta` 파싱 확장
+3. 세션 종류 판별 helper 추가
+4. `collect_codex_sessions()`에서 `Subagent` 기본 제외
+5. 테스트 추가
+6. README에 동작 문서화

--- a/src/analyzer/prompt.rs
+++ b/src/analyzer/prompt.rs
@@ -514,6 +514,9 @@ mod tests {
                 session_id: "s1".to_string(),
                 cwd: "/tmp".to_string(),
                 model_provider: "openai".to_string(),
+                subagent_source: None,
+                agent_role: None,
+                agent_nickname: None,
                 text: "s1\n/tmp\nopenai".to_string(),
             },
             CodexEntry::UserMessage {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1042,6 +1042,11 @@ fn collect_codex_sessions(
     for mut entries in merged_entries.into_values() {
         entries = parser::codex::dedupe_entries(entries);
         parser::codex::sort_entries_by_timestamp(&mut entries);
+        if parser::codex::classify_codex_session(&entries)
+            == parser::codex::CodexSessionKind::Subagent
+        {
+            continue;
+        }
         let summary = parser::codex::summarize_codex_entries(&entries);
         if summary.user_count > 0 || summary.assistant_count > 0 {
             sessions.push((summary, entries));
@@ -1420,6 +1425,30 @@ mod tests {
         ))
     }
 
+    fn write_codex_rollout(
+        file: &std::path::Path,
+        session_id: &str,
+        cwd: &str,
+        extra_meta: &str,
+    ) {
+        let mut handle = std::fs::File::create(file).expect("rollout file");
+        writeln!(
+            handle,
+            r#"{{"timestamp":"2099-01-01T12:00:00Z","type":"session_meta","payload":{{"id":"{session_id}","cwd":"{cwd}","model_provider":"openai"{extra_meta}}}}}"#
+        )
+        .expect("session meta");
+        writeln!(
+            handle,
+            r#"{{"timestamp":"2099-01-01T12:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"hello"}}}}"#
+        )
+        .expect("user message");
+        writeln!(
+            handle,
+            r#"{{"timestamp":"2099-01-01T12:02:00Z","type":"response_item","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"done"}}]}}}}"#
+        )
+        .expect("assistant message");
+    }
+
     #[test]
     fn test_collect_claude_entries_dedupes_across_roots() {
         // Use a far-future date to avoid collisions with real local logs.
@@ -1523,6 +1552,115 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_codex_sessions_excludes_explicit_subagent_sessions() {
+        let date = chrono::NaiveDate::from_ymd_opt(2099, 1, 1).expect("date");
+        let base = unique_temp_dir("rwd_test_codex_subagent_excluded");
+        let root = base.join("codex-root");
+        let day_dir = root.join("2099").join("01").join("01");
+        std::fs::create_dir_all(&day_dir).expect("day dir");
+
+        let rollout_file = day_dir.join("rollout-subagent.jsonl");
+        write_codex_rollout(
+            &rollout_file,
+            "codex-subagent-1",
+            "/Users/jinwoohan/.codex/memories",
+            r#","source":{"subagent":"memory_consolidation"},"agent_role":"memory builder","agent_nickname":"Morpheus""#,
+        );
+
+        let cfg = test_config(Some(vec![root.to_string_lossy().to_string()]), None);
+        let (sessions, roots) = collect_codex_sessions(date, Some(&cfg));
+
+        assert!(roots.starts_with(std::slice::from_ref(&root)));
+        assert!(sessions.is_empty());
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_collect_codex_sessions_excludes_mixed_session_id_when_merged_session_is_subagent() {
+        let date = chrono::NaiveDate::from_ymd_opt(2099, 1, 1).expect("date");
+        let base = unique_temp_dir("rwd_test_codex_mixed_session_id_subagent");
+        let root_a = base.join("codex-a");
+        let root_b = base.join("codex-b");
+        let day_dir_a = root_a.join("2099").join("01").join("01");
+        let day_dir_b = root_b.join("2099").join("01").join("01");
+        std::fs::create_dir_all(&day_dir_a).expect("day a");
+        std::fs::create_dir_all(&day_dir_b).expect("day b");
+
+        let mut file_a = std::fs::File::create(day_dir_a.join("rollout-a.jsonl")).expect("file a");
+        writeln!(
+            file_a,
+            r#"{{"timestamp":"2099-01-01T12:00:00Z","type":"session_meta","payload":{{"id":"codex-mixed-1","cwd":"/Users/jinwoohan/.codex/memories","model_provider":"openai","source":{{"subagent":"memory_consolidation"}},"agent_role":"memory builder","agent_nickname":"Morpheus"}}}}"#
+        )
+        .expect("subagent meta");
+        writeln!(
+            file_a,
+            r#"{{"timestamp":"2099-01-01T12:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"hello from subagent"}}}}"#
+        )
+        .expect("subagent user");
+
+        let mut file_b = std::fs::File::create(day_dir_b.join("rollout-b.jsonl")).expect("file b");
+        writeln!(
+            file_b,
+            r#"{{"timestamp":"2099-01-01T12:00:00Z","type":"session_meta","payload":{{"id":"codex-mixed-1","cwd":"/Users/jinwoohan/workspace/repos/personal/rwd","model_provider":"openai","source":"cli"}}}}"#
+        )
+        .expect("interactive meta");
+        writeln!(
+            file_b,
+            r#"{{"timestamp":"2099-01-01T12:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"hello from interactive"}}}}"#
+        )
+        .expect("interactive user");
+        writeln!(
+            file_b,
+            r#"{{"timestamp":"2099-01-01T12:02:00Z","type":"response_item","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"done"}}]}}}}"#
+        )
+        .expect("interactive assistant");
+
+        let cfg = test_config(
+            Some(vec![
+                root_a.to_string_lossy().to_string(),
+                root_b.to_string_lossy().to_string(),
+            ]),
+            None,
+        );
+        let (sessions, roots) = collect_codex_sessions(date, Some(&cfg));
+
+        assert!(roots.starts_with(&[root_a.clone(), root_b.clone()]));
+        assert!(sessions.is_empty());
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn test_collect_codex_sessions_keeps_worktree_interactive_sessions_without_hard_signal() {
+        let date = chrono::NaiveDate::from_ymd_opt(2099, 1, 1).expect("date");
+        let base = unique_temp_dir("rwd_test_codex_worktree_interactive");
+        let root = base.join("codex-root");
+        let day_dir = root.join("2099").join("01").join("01");
+        std::fs::create_dir_all(&day_dir).expect("day dir");
+
+        let worktree_cwd = "/Users/jinwoohan/.codex/worktrees/1234/rwd".to_string();
+        let rollout_file = day_dir.join("rollout-interactive.jsonl");
+        write_codex_rollout(&rollout_file, "codex-worktree-1", &worktree_cwd, r#","source":"cli""#);
+
+        let cfg = test_config(Some(vec![root.to_string_lossy().to_string()]), None);
+        let (sessions, roots) = collect_codex_sessions(date, Some(&cfg));
+
+        assert!(roots.starts_with(std::slice::from_ref(&root)));
+        assert_eq!(sessions.len(), 1);
+        let (summary, entries) = &sessions[0];
+        assert_eq!(summary.session_id, "codex-worktree-1");
+        assert_eq!(summary.cwd, worktree_cwd);
+        assert_eq!(
+            parser::codex::classify_codex_session(entries),
+            parser::codex::CodexSessionKind::Interactive
+        );
+        assert!(matches!(entries.first(), Some(parser::codex::CodexEntry::SessionMeta { .. })));
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
     fn test_codex_time_range_ignores_previous_day_session_meta() {
         let session_meta_ts = chrono::Local
             .with_ymd_and_hms(2099, 1, 1, 23, 28, 0)
@@ -1556,6 +1694,9 @@ mod tests {
                     session_id: "s1".to_string(),
                     cwd: "/tmp".to_string(),
                     model_provider: "openai".to_string(),
+                    subagent_source: None,
+                    agent_role: None,
+                    agent_nickname: None,
                     text: "s1\n/tmp\nopenai".to_string(),
                 },
                 parser::codex::CodexEntry::UserMessage {

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -130,6 +130,10 @@ fn extract_subagent_source(payload: &serde_json::Value) -> Option<String> {
     optional_non_empty_string(source.get("subagent")?)
 }
 
+/// Returns `Subagent` if any `SessionMeta` entry carries an explicit hard
+/// signal (`source.subagent`, `agent_role`, or `agent_nickname`); otherwise
+/// `Interactive`. Conservative by design: a single hard signal in any merged
+/// entry classifies the whole session as a subagent.
 pub fn classify_codex_session(entries: &[CodexEntry]) -> CodexSessionKind {
     for entry in entries {
         if let CodexEntry::SessionMeta {

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -39,6 +39,9 @@ pub enum CodexEntry {
         session_id: String,
         cwd: String,
         model_provider: String,
+        subagent_source: Option<String>,
+        agent_role: Option<String>,
+        agent_nickname: Option<String>,
         text: String,
     },
     /// User input message
@@ -63,6 +66,13 @@ pub enum CodexEntry {
         entry_type: String,
         text: String,
     },
+}
+
+/// Classifies Codex sessions from explicit SessionMeta metadata only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexSessionKind {
+    Interactive,
+    Subagent,
 }
 
 fn collect_json_string_leaves(value: &serde_json::Value, out: &mut Vec<String>) {
@@ -107,6 +117,36 @@ fn extract_payload_text(payload: &serde_json::Value) -> String {
     join_unique_lines(&parts)
 }
 
+fn optional_non_empty_string(value: &serde_json::Value) -> Option<String> {
+    let text = value.as_str()?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    Some(text.to_string())
+}
+
+fn extract_subagent_source(payload: &serde_json::Value) -> Option<String> {
+    let source = payload.get("source")?.as_object()?;
+    optional_non_empty_string(source.get("subagent")?)
+}
+
+pub fn classify_codex_session(entries: &[CodexEntry]) -> CodexSessionKind {
+    for entry in entries {
+        if let CodexEntry::SessionMeta {
+            subagent_source,
+            agent_role,
+            agent_nickname,
+            ..
+        } = entry
+            && (subagent_source.is_some() || agent_role.is_some() || agent_nickname.is_some())
+        {
+            return CodexSessionKind::Subagent;
+        }
+    }
+
+    CodexSessionKind::Interactive
+}
+
 impl CodexEntry {
     /// Converts a CodexRawEntry into a structured CodexEntry variant.
     /// Missing fields default to empty strings since the Codex JSONL schema
@@ -125,11 +165,21 @@ impl CodexEntry {
                     .as_str()
                     .unwrap_or_default()
                     .to_string();
+                let subagent_source = extract_subagent_source(payload);
+                let agent_role = payload
+                    .get("agent_role")
+                    .and_then(optional_non_empty_string);
+                let agent_nickname = payload
+                    .get("agent_nickname")
+                    .and_then(optional_non_empty_string);
                 CodexEntry::SessionMeta {
                     timestamp: ts,
                     session_id,
                     cwd,
                     model_provider,
+                    subagent_source,
+                    agent_role,
+                    agent_nickname,
                     text: payload_text.clone(),
                 }
             }
@@ -339,6 +389,9 @@ enum CodexEntryFingerprint {
         session_id: String,
         cwd: String,
         model_provider: String,
+        subagent_source: Option<String>,
+        agent_role: Option<String>,
+        agent_nickname: Option<String>,
         text: String,
     },
     UserMessage {
@@ -368,12 +421,18 @@ fn entry_fingerprint(entry: &CodexEntry) -> CodexEntryFingerprint {
             session_id,
             cwd,
             model_provider,
+            subagent_source,
+            agent_role,
+            agent_nickname,
             text,
         } => CodexEntryFingerprint::SessionMeta {
             timestamp_millis: timestamp.timestamp_millis(),
             session_id: session_id.clone(),
             cwd: cwd.clone(),
             model_provider: model_provider.clone(),
+            subagent_source: subagent_source.clone(),
+            agent_role: agent_role.clone(),
+            agent_nickname: agent_nickname.clone(),
             text: text.clone(),
         },
         CodexEntry::UserMessage { timestamp, text } => CodexEntryFingerprint::UserMessage {
@@ -505,6 +564,141 @@ mod tests {
         } else {
             panic!("Expected SessionMeta variant");
         }
+    }
+
+    #[test]
+    fn test_parse_session_meta_entry_preserves_subagent_metadata() {
+        let json = r#"{"timestamp":"2026-04-22T09:00:00Z","type":"session_meta","payload":{"id":"sess-sub","cwd":"/Users/jinwoohan/.codex/memories","model_provider":"openai","source":{"subagent":"memory_consolidation"},"agent_role":"memory builder","agent_nickname":"Morpheus"}}"#;
+        let raw: CodexRawEntry = serde_json::from_str(json).unwrap();
+        let entry = CodexEntry::from_raw(raw);
+
+        if let CodexEntry::SessionMeta {
+            session_id,
+            cwd,
+            model_provider,
+            subagent_source,
+            agent_role,
+            agent_nickname,
+            ..
+        } = entry
+        {
+            assert_eq!(session_id, "sess-sub");
+            assert_eq!(cwd, "/Users/jinwoohan/.codex/memories");
+            assert_eq!(model_provider, "openai");
+            assert_eq!(subagent_source.as_deref(), Some("memory_consolidation"));
+            assert_eq!(agent_role.as_deref(), Some("memory builder"));
+            assert_eq!(agent_nickname.as_deref(), Some("Morpheus"));
+        } else {
+            panic!("Expected SessionMeta variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_session_meta_entry_ignores_string_source_for_subagent_detection() {
+        let json = r#"{"timestamp":"2026-04-22T09:00:00Z","type":"session_meta","payload":{"id":"sess-cli","cwd":"/Users/jinwoohan/workspace/repos/personal/rwd","model_provider":"openai","source":"cli"}}"#;
+        let raw: CodexRawEntry = serde_json::from_str(json).unwrap();
+        let entry = CodexEntry::from_raw(raw);
+
+        if let CodexEntry::SessionMeta {
+            subagent_source,
+            agent_role,
+            agent_nickname,
+            ..
+        } = entry
+        {
+            assert_eq!(subagent_source, None);
+            assert_eq!(agent_role, None);
+            assert_eq!(agent_nickname, None);
+        } else {
+            panic!("Expected SessionMeta variant");
+        }
+    }
+
+    fn classify_session_meta(
+        session_id: &str,
+        cwd: &str,
+        subagent_source: Option<&str>,
+        agent_role: Option<&str>,
+        agent_nickname: Option<&str>,
+    ) -> CodexEntry {
+        use chrono::TimeZone;
+
+        CodexEntry::SessionMeta {
+            timestamp: chrono::Utc
+                .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
+                .unwrap(),
+            session_id: session_id.to_string(),
+            cwd: cwd.to_string(),
+            model_provider: "openai".to_string(),
+            subagent_source: subagent_source.map(str::to_string),
+            agent_role: agent_role.map(str::to_string),
+            agent_nickname: agent_nickname.map(str::to_string),
+            text: "subagent".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_classify_codex_session_kind_interactive_when_only_suspicious_cwd_present() {
+        let entries = vec![classify_session_meta(
+            "interactive",
+            "/Users/jinwoohan/.codex/worktrees/1234/rwd",
+            None,
+            None,
+            None,
+        )];
+
+        assert_eq!(
+            classify_codex_session(&entries),
+            CodexSessionKind::Interactive
+        );
+    }
+
+    #[test]
+    fn test_classify_codex_session_kind_uses_subagent_source_only() {
+        let entries = vec![classify_session_meta(
+            "subagent-source",
+            "/Users/jinwoohan/workspace/repos/personal/rwd",
+            Some("memory_consolidation"),
+            None,
+            None,
+        )];
+
+        assert_eq!(
+            classify_codex_session(&entries),
+            CodexSessionKind::Subagent
+        );
+    }
+
+    #[test]
+    fn test_classify_codex_session_kind_uses_agent_role_only() {
+        let entries = vec![classify_session_meta(
+            "subagent-role",
+            "/Users/jinwoohan/.codex/memories",
+            None,
+            Some("memory builder"),
+            None,
+        )];
+
+        assert_eq!(
+            classify_codex_session(&entries),
+            CodexSessionKind::Subagent
+        );
+    }
+
+    #[test]
+    fn test_classify_codex_session_kind_uses_agent_nickname_only() {
+        let entries = vec![classify_session_meta(
+            "subagent-nickname",
+            "/Users/jinwoohan/.codex/memories",
+            None,
+            None,
+            Some("Morpheus"),
+        )];
+
+        assert_eq!(
+            classify_codex_session(&entries),
+            CodexSessionKind::Subagent
+        );
     }
 
     #[test]
@@ -660,6 +854,9 @@ mod tests {
                 session_id: "s1".to_string(),
                 cwd: "/p".to_string(),
                 model_provider: "openai".to_string(),
+                subagent_source: None,
+                agent_role: None,
+                agent_nickname: None,
                 text: "s1\n/p\nopenai".to_string(),
             },
             CodexEntry::UserMessage {
@@ -723,6 +920,9 @@ mod tests {
                 session_id: "s1".to_string(),
                 cwd: "/p".to_string(),
                 model_provider: "openai".to_string(),
+                subagent_source: None,
+                agent_role: None,
+                agent_nickname: None,
                 text: "s1\n/p\nopenai".to_string(),
             },
             CodexEntry::UserMessage {
@@ -767,6 +967,9 @@ mod tests {
                 session_id: "s1".to_string(),
                 cwd: "/p".to_string(),
                 model_provider: "openai".to_string(),
+                subagent_source: None,
+                agent_role: None,
+                agent_nickname: None,
                 text: "s1\n/p\nopenai".to_string(),
             },
             CodexEntry::UserMessage {
@@ -793,6 +996,9 @@ mod tests {
                 session_id: "s1".to_string(),
                 cwd: "/p".to_string(),
                 model_provider: "openai".to_string(),
+                subagent_source: None,
+                agent_role: None,
+                agent_nickname: None,
                 text: "s1\n/p\nopenai".to_string(),
             },
             CodexEntry::UserMessage {
@@ -825,6 +1031,9 @@ mod tests {
                 session_id: "s1".to_string(),
                 cwd: "/p".to_string(),
                 model_provider: "openai".to_string(),
+                subagent_source: None,
+                agent_role: None,
+                agent_nickname: None,
                 text: "s1\n/p\nopenai".to_string(),
             },
             CodexEntry::UserMessage {

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -614,7 +614,7 @@ mod tests {
         }
     }
 
-    fn classify_session_meta(
+    fn make_session_meta_entry(
         session_id: &str,
         cwd: &str,
         subagent_source: Option<&str>,
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_classify_codex_session_kind_interactive_when_only_suspicious_cwd_present() {
-        let entries = vec![classify_session_meta(
+        let entries = vec![make_session_meta_entry(
             "interactive",
             "/Users/jinwoohan/.codex/worktrees/1234/rwd",
             None,
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_classify_codex_session_kind_uses_subagent_source_only() {
-        let entries = vec![classify_session_meta(
+        let entries = vec![make_session_meta_entry(
             "subagent-source",
             "/Users/jinwoohan/workspace/repos/personal/rwd",
             Some("memory_consolidation"),
@@ -671,7 +671,7 @@ mod tests {
 
     #[test]
     fn test_classify_codex_session_kind_uses_agent_role_only() {
-        let entries = vec![classify_session_meta(
+        let entries = vec![make_session_meta_entry(
             "subagent-role",
             "/Users/jinwoohan/.codex/memories",
             None,
@@ -687,7 +687,7 @@ mod tests {
 
     #[test]
     fn test_classify_codex_session_kind_uses_agent_nickname_only() {
-        let entries = vec![classify_session_meta(
+        let entries = vec![make_session_meta_entry(
             "subagent-nickname",
             "/Users/jinwoohan/.codex/memories",
             None,


### PR DESCRIPTION
## Summary
- `session_meta`의 hard signal(`source.subagent`, `agent_role`, `agent_nickname`)만으로 Codex subagent 세션을 기본 제외
- worktree `cwd` 패턴이나 프롬프트 휴리스틱은 사용하지 않음 — interactive worktree 세션은 그대로 포함
- README에 Codex 필터링 정책 명시

## Changes
- [docs/superpowers/specs/...-design.md](docs/superpowers/specs/2026-04-22-codex-subagent-session-filtering-design.md): 설계 문서 (문제/관찰/솔루션)
- [docs/superpowers/plans/...-filtering.md](docs/superpowers/plans/2026-04-22-codex-subagent-session-filtering.md): 구현 계획 (Task 1~4)
- [src/parser/codex.rs](src/parser/codex.rs): `SessionMeta` 확장 (`subagent_source`, `agent_role`, `agent_nickname`), `CodexSessionKind` 분류 helper
- [src/main.rs](src/main.rs): `collect_codex_sessions()`에 hard-signal subagent early-continue, collection tests 2개
- [src/analyzer/prompt.rs](src/analyzer/prompt.rs): 확장된 `SessionMeta` fixture 컴파일 유지
- [README.md](README.md): Codex session filtering 섹션

## Test plan
- [x] `cargo build` 통과
- [x] `cargo clippy` warning 0
- [x] `cargo test` — 217 passed, 0 failed
- [x] `test_collect_codex_sessions_excludes_explicit_subagent_sessions` 통과
- [x] `test_collect_codex_sessions_keeps_worktree_interactive_sessions_without_hard_signal` 통과
- [x] `test_collect_codex_sessions_excludes_mixed_session_id_when_merged_session_is_subagent` 통과