### PR TITLE
chore: cargo fmt

### DIFF
--- a/src/analyzer/compaction.rs
+++ b/src/analyzer/compaction.rs
@@ -336,8 +336,7 @@ mod tests {
     }
 
     fn big_flutter_block(n: usize) -> String {
-        let line =
-            "flutter: ✅ [Sounds] 경로 기반 프리로드 완료 (성공: 63, 실패: 0)\n";
+        let line = "flutter: ✅ [Sounds] 경로 기반 프리로드 완료 (성공: 63, 실패: 0)\n";
         line.repeat(n)
     }
 

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -732,13 +732,15 @@ fn should_force_summarize_by_chars(
     conversation_text: &str,
     extra_chars: usize,
 ) -> bool {
-    provider.max_conversation_chars(lang).is_some_and(|max_chars| {
-        conversation_text
-            .chars()
-            .count()
-            .saturating_add(extra_chars)
-            > max_chars
-    })
+    provider
+        .max_conversation_chars(lang)
+        .is_some_and(|max_chars| {
+            conversation_text
+                .chars()
+                .count()
+                .saturating_add(extra_chars)
+                > max_chars
+        })
 }
 
 /// Direct step: sends the session prompt as-is.

--- a/src/analyzer/prompt.rs
+++ b/src/analyzer/prompt.rs
@@ -269,9 +269,7 @@ pub fn extract_codex_messages(entries: &[CodexEntry]) -> Vec<(String, String)> {
     codex_role_text_pairs(entries).collect()
 }
 
-fn codex_role_text_pairs(
-    entries: &[CodexEntry],
-) -> impl Iterator<Item = (String, String)> + '_ {
+fn codex_role_text_pairs(entries: &[CodexEntry]) -> impl Iterator<Item = (String, String)> + '_ {
     // Prompt policy:
     //   - USER / ASSISTANT messages keep full (compacted) text: they are the
     //     core material for insight extraction.
@@ -283,12 +281,14 @@ fn codex_role_text_pairs(
     //     shipping megabytes of tool-output text through the LLM call.
     //   - SessionMeta is preserved as-is (short by construction).
     entries.iter().filter_map(|entry| match entry {
-        CodexEntry::SessionMeta { text, .. } if !text.is_empty() => {
-            Some(("META".to_string(), super::compaction::compact_log_like(text)))
-        }
-        CodexEntry::UserMessage { text, .. } if !text.is_empty() => {
-            Some(("USER".to_string(), super::compaction::compact_log_like(text)))
-        }
+        CodexEntry::SessionMeta { text, .. } if !text.is_empty() => Some((
+            "META".to_string(),
+            super::compaction::compact_log_like(text),
+        )),
+        CodexEntry::UserMessage { text, .. } if !text.is_empty() => Some((
+            "USER".to_string(),
+            super::compaction::compact_log_like(text),
+        )),
         CodexEntry::AssistantMessage { text, .. } if !text.is_empty() => Some((
             "ASSISTANT".to_string(),
             super::compaction::compact_log_like(text),

--- a/src/analyzer/provider.rs
+++ b/src/analyzer/provider.rs
@@ -67,7 +67,9 @@ impl LlmProvider {
     /// None means no explicit character cap is enforced here.
     pub fn max_conversation_chars(&self, lang: &Lang) -> Option<usize> {
         match self {
-            LlmProvider::Codex { .. } => Some(codex_max_conversation_chars(get_system_prompt(lang))),
+            LlmProvider::Codex { .. } => {
+                Some(codex_max_conversation_chars(get_system_prompt(lang)))
+            }
             _ => None,
         }
     }

--- a/src/analyzer/summarizer.rs
+++ b/src/analyzer/summarizer.rs
@@ -230,5 +230,4 @@ mod tests {
         let wait = calculate_wait(100, &limits);
         assert!((wait - 1.2).abs() < 0.1);
     }
-
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -155,8 +155,8 @@ pub enum AuthAction {
 #[cfg(test)]
 mod tests {
     use super::{Cli, Commands};
-    use clap::error::ErrorKind;
     use clap::Parser;
+    use clap::error::ErrorKind;
 
     #[test]
     fn test_parse_version_subcommand() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1425,12 +1425,7 @@ mod tests {
         ))
     }
 
-    fn write_codex_rollout(
-        file: &std::path::Path,
-        session_id: &str,
-        cwd: &str,
-        extra_meta: &str,
-    ) {
+    fn write_codex_rollout(file: &std::path::Path, session_id: &str, cwd: &str, extra_meta: &str) {
         let mut handle = std::fs::File::create(file).expect("rollout file");
         writeln!(
             handle,
@@ -1641,7 +1636,12 @@ mod tests {
 
         let worktree_cwd = "/Users/jinwoohan/.codex/worktrees/1234/rwd".to_string();
         let rollout_file = day_dir.join("rollout-interactive.jsonl");
-        write_codex_rollout(&rollout_file, "codex-worktree-1", &worktree_cwd, r#","source":"cli""#);
+        write_codex_rollout(
+            &rollout_file,
+            "codex-worktree-1",
+            &worktree_cwd,
+            r#","source":"cli""#,
+        );
 
         let cfg = test_config(Some(vec![root.to_string_lossy().to_string()]), None);
         let (sessions, roots) = collect_codex_sessions(date, Some(&cfg));
@@ -1655,7 +1655,10 @@ mod tests {
             parser::codex::classify_codex_session(entries),
             parser::codex::CodexSessionKind::Interactive
         );
-        assert!(matches!(entries.first(), Some(parser::codex::CodexEntry::SessionMeta { .. })));
+        assert!(matches!(
+            entries.first(),
+            Some(parser::codex::CodexEntry::SessionMeta { .. })
+        ));
 
         std::fs::remove_dir_all(&base).ok();
     }

--- a/src/parser/codex.rs
+++ b/src/parser/codex.rs
@@ -628,9 +628,7 @@ mod tests {
         use chrono::TimeZone;
 
         CodexEntry::SessionMeta {
-            timestamp: chrono::Utc
-                .with_ymd_and_hms(2026, 4, 22, 9, 0, 0)
-                .unwrap(),
+            timestamp: chrono::Utc.with_ymd_and_hms(2026, 4, 22, 9, 0, 0).unwrap(),
             session_id: session_id.to_string(),
             cwd: cwd.to_string(),
             model_provider: "openai".to_string(),
@@ -667,10 +665,7 @@ mod tests {
             None,
         )];
 
-        assert_eq!(
-            classify_codex_session(&entries),
-            CodexSessionKind::Subagent
-        );
+        assert_eq!(classify_codex_session(&entries), CodexSessionKind::Subagent);
     }
 
     #[test]
@@ -683,10 +678,7 @@ mod tests {
             None,
         )];
 
-        assert_eq!(
-            classify_codex_session(&entries),
-            CodexSessionKind::Subagent
-        );
+        assert_eq!(classify_codex_session(&entries), CodexSessionKind::Subagent);
     }
 
     #[test]
@@ -699,10 +691,7 @@ mod tests {
             Some("Morpheus"),
         )];
 
-        assert_eq!(
-            classify_codex_session(&entries),
-            CodexSessionKind::Subagent
-        );
+        assert_eq!(classify_codex_session(&entries), CodexSessionKind::Subagent);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- 무관한 파일들의 누적된 `cargo fmt` 차이를 한 번에 정리
- 후속 PR(#136/#137/#138 fix)들의 diff에서 fmt 노이즈 제거 목적

## Test plan
- [x] `cargo fmt --check` 통과
- [x] `cargo build` 통과
- [x] `cargo test` 217 passed