### PR TITLE
fix(openai): drop response_format on chunk summary calls

### DIFF
--- a/src/analyzer/openai.rs
+++ b/src/analyzer/openai.rs
@@ -12,7 +12,8 @@ struct ChatRequest {
     model: String,
     messages: Vec<ChatMessage>,
     max_tokens: u32,
-    response_format: ResponseFormat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<ResponseFormat>,
 }
 
 /// Forces JSON output mode.
@@ -80,9 +81,9 @@ pub async fn call_openai_api(
             },
         ],
         max_tokens,
-        response_format: ResponseFormat {
+        response_format: Some(ResponseFormat {
             format_type: "json_object".to_string(),
-        },
+        }),
     };
 
     let response = client
@@ -118,6 +119,12 @@ pub async fn call_openai_api(
 }
 
 /// API call variant with explicit max_tokens.
+///
+/// Used for chunk summarization, which produces free-form text rather than
+/// JSON. We deliberately omit `response_format: json_object` here because
+/// OpenAI requires the literal word "json" to appear somewhere in the
+/// messages whenever that mode is set, and chunk-summary prompts do not
+/// mention JSON.
 pub async fn call_openai_api_with_max_tokens(
     api_key: &str,
     system_prompt: &str,
@@ -138,9 +145,7 @@ pub async fn call_openai_api_with_max_tokens(
             },
         ],
         max_tokens,
-        response_format: ResponseFormat {
-            format_type: "json_object".to_string(),
-        },
+        response_format: None,
     };
     let response = client
         .post(API_URL)


### PR DESCRIPTION
## Summary
- `call_openai_api_with_max_tokens`(청크 요약 전용)에서 `response_format: json_object` 제거
- OpenAI는 `response_format: json_object`를 사용할 때 메시지 어딘가에 "json" 단어 포함을 요구. `chunk_summarize_*.md` 프롬프트는 자유 텍스트 요약을 요구해 "json" 미포함 → HTTP 400 (`'messages' must contain the word 'json'`)
- 최종 세션 분석(`call_openai_api`)은 system 프롬프트가 이미 "JSON"을 명시하므로 그대로 둠

## Verification
- 8개 세션을 강제 청크 분할(임시 ITPM=1000)하여 실제 OpenAI에 reproducer 실행 → 모든 chunk 200 OK, 400 에러 0건
- 검증 후 임시 패치 원복

Fixes #137

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` 217 passed
- [x] 실제 OpenAI API end-to-end 호출 검증