### PR TITLE
feat(config): expand ${VAR} env placeholders in API key fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ rwd reset --dry-run                      # Preview reset targets
 rwd reset --yes                          # Reset local config/cache state
 ```
 
+### API keys via environment variables
+
+`openai_api_key` and `anthropic_api_key` in `~/.config/rwd/config.toml`
+support `${VAR}` placeholders, expanded from the process environment at
+runtime. Use this to keep secrets out of the file (and out of backups
+like Time Machine / iCloud):
+
+```toml
+[llm]
+provider = "openai"
+openai_api_key = "${OPENAI_API_KEY}"
+```
+
+If the referenced variable is not set when `rwd` runs, the command fails
+with a clear error naming the missing variable. Literal keys (those
+without a `${...}` placeholder) keep working unchanged.
+
 ### Sensitive data masking
 
 When running `rwd today`, sensitive data in session logs (API keys, tokens, private IPs, etc.) is automatically masked before sending to the LLM. Enabled by default. To disable, add to `~/.config/rwd/config.toml`:

--- a/src/analyzer/provider.rs
+++ b/src/analyzer/provider.rs
@@ -251,11 +251,19 @@ impl LlmProvider {
 }
 
 /// Loads the LLM provider and API key from config (~/.config/rwd/config.toml).
+///
+/// `${VAR}` placeholders in API key fields are resolved from the process
+/// environment, so `openai_api_key = "${OPENAI_API_KEY}"` keeps the secret
+/// out of config.toml.
 pub fn load_provider() -> Result<(LlmProvider, String), super::AnalyzerError> {
     let config = crate::config::load_config_if_exists().ok_or(crate::messages::error::NO_CONFIG)?;
 
+    let resolve = |raw: &str| -> Result<String, super::AnalyzerError> {
+        crate::config::resolve_env_placeholders(raw).map_err(|e| e.to_string().into())
+    };
+
     let (provider, api_key) = match config.llm.provider.as_str() {
-        "openai" => (LlmProvider::OpenAi, config.llm.openai_api_key.clone()),
+        "openai" => (LlmProvider::OpenAi, resolve(&config.llm.openai_api_key)?),
         "codex" => {
             let model = config
                 .llm
@@ -277,7 +285,10 @@ pub fn load_provider() -> Result<(LlmProvider, String), super::AnalyzerError> {
                 String::new(),
             )
         }
-        "anthropic" => (LlmProvider::Anthropic, config.llm.anthropic_api_key.clone()),
+        "anthropic" => (
+            LlmProvider::Anthropic,
+            resolve(&config.llm.anthropic_api_key)?,
+        ),
         other => return Err(crate::messages::error::unsupported_provider_in_config(other).into()),
     };
     Ok((provider, api_key))

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,6 +213,55 @@ pub fn load_config_if_exists() -> Option<Config> {
     }
 }
 
+/// Resolves `${VAR}` placeholders in `template` from process environment.
+///
+/// Used to keep API keys out of config.toml on disk: users may write
+/// `openai_api_key = "${OPENAI_API_KEY}"` and have rwd read the actual
+/// secret from the shell environment at runtime. Only `${NAME}` is
+/// recognized (no `$NAME` shorthand) and only ASCII letters, digits, and
+/// underscores are allowed in the variable name. Strings with no placeholder
+/// pass through unchanged so existing literal-key configs keep working.
+pub fn resolve_env_placeholders(template: &str) -> Result<String, ConfigError> {
+    if !template.contains("${") {
+        return Ok(template.to_string());
+    }
+
+    let bytes = template.as_bytes();
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            let start = i + 2;
+            let Some(end_off) = bytes[start..].iter().position(|&b| b == b'}') else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            let end = start + end_off;
+            let name = &template[start..end];
+            if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                // Not a valid env-var reference; emit literally.
+                out.push_str(&template[i..=end]);
+                i = end + 1;
+                continue;
+            }
+            let value =
+                std::env::var(name).map_err(|_| crate::messages::config::missing_env_var(name))?;
+            out.push_str(&value);
+            i = end + 1;
+        } else {
+            // Push one UTF-8 char at a time to avoid splitting code points.
+            let ch_len = template[i..]
+                .chars()
+                .next()
+                .map(|c| c.len_utf8())
+                .unwrap_or(1);
+            out.push_str(&template[i..i + ch_len]);
+            i += ch_len;
+        }
+    }
+    Ok(out)
+}
+
 /// `rwd init` — prompts for API key, detects output path, and saves config.
 pub fn run_init() -> Result<(), ConfigError> {
     let config_file = config_path()?;
@@ -778,6 +827,17 @@ async fn verify_api_key(provider: &str, api_key: &str) {
     let green = "\x1b[32m";
     let yellow = "\x1b[33m";
     let reset = "\x1b[0m";
+
+    // Resolve `${VAR}` placeholders so verify works against the live secret,
+    // not the template string stored on disk.
+    let resolved = match resolve_env_placeholders(api_key) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("\r{yellow}{e}{reset}");
+            return;
+        }
+    };
+    let api_key = resolved.as_str();
 
     if provider == "codex" {
         eprint!(
@@ -1802,5 +1862,51 @@ path = "/tmp/vault"
             infer_codex_login_state(true, "Logged in", "Not logged in"),
             CodexLoginState::NotLoggedIn
         );
+    }
+
+    #[test]
+    fn test_resolve_env_placeholders_passthrough_when_no_placeholder() {
+        let out = resolve_env_placeholders("sk-literal-key").expect("no placeholder");
+        assert_eq!(out, "sk-literal-key");
+    }
+
+    #[test]
+    fn test_resolve_env_placeholders_substitutes_known_var() {
+        // SAFETY: setting an env var on a single-threaded test point.
+        unsafe {
+            std::env::set_var("RWD_TEST_RESOLVE_KEY", "from-env");
+        }
+        let out =
+            resolve_env_placeholders("prefix-${RWD_TEST_RESOLVE_KEY}-suffix").expect("resolves");
+        assert_eq!(out, "prefix-from-env-suffix");
+        unsafe {
+            std::env::remove_var("RWD_TEST_RESOLVE_KEY");
+        }
+    }
+
+    #[test]
+    fn test_resolve_env_placeholders_errors_on_missing_var() {
+        unsafe {
+            std::env::remove_var("RWD_TEST_RESOLVE_MISSING");
+        }
+        let err = resolve_env_placeholders("${RWD_TEST_RESOLVE_MISSING}").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("RWD_TEST_RESOLVE_MISSING"),
+            "error should name the missing var, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_env_placeholders_emits_invalid_token_literally() {
+        // `${ }` (with a space) is not a valid env-var name; pass it through.
+        let out = resolve_env_placeholders("hello ${not a var} world").expect("literal");
+        assert_eq!(out, "hello ${not a var} world");
+    }
+
+    #[test]
+    fn test_resolve_env_placeholders_unterminated_brace_passes_through() {
+        let out = resolve_env_placeholders("${OPEN_AI_KEY").expect("passes through");
+        assert_eq!(out, "${OPEN_AI_KEY");
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -142,6 +142,12 @@ pub mod config {
             "Unsupported codex reasoning effort: '{value}'. Available: low, medium, high, xhigh, default"
         )
     }
+
+    pub fn missing_env_var(name: &str) -> String {
+        format!(
+            "Environment variable `{name}` referenced in config is not set. Export it before running rwd, or replace the placeholder with a literal value."
+        )
+    }
 }
 
 /// Messages for `rwd reset`.


### PR DESCRIPTION
## Summary
- `~/.config/rwd/config.toml`의 `openai_api_key` / `anthropic_api_key`에서 `${VAR}` 형태 placeholder를 프로세스 환경변수로 치환
- 평문 secret이 config 파일에 남지 않도록 (Time Machine / iCloud 백업, 스크린샷/공유 노출 방지)

## Behavior
- `openai_api_key = "${OPENAI_API_KEY}"` → 런타임에 환경변수에서 읽음
- placeholder 없는 literal 키는 그대로 동작 (호환성 유지)
- 환경변수 미설정 시 명확한 에러: `Environment variable \`X\` referenced in config is not set...`
- 잘못된 형태(`${ }`, 미종결)는 literal로 통과

## Changes
- [src/config.rs](src/config.rs): `resolve_env_placeholders()` 함수 + 5개 unit test, `verify_api_key`에서 호출
- [src/analyzer/provider.rs](src/analyzer/provider.rs): `load_provider`가 API key 추출 후 치환
- [src/messages.rs](src/messages.rs): `missing_env_var` 에러 메시지
- [README.md](README.md): "API keys via environment variables" 섹션

Refs #138 (Phase 1 — env var substitution)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` 222 passed (5 new env-resolve tests)