### PR TITLE
feat(claude): drop subagent (sidechain) entries from session counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ Update notice env toggles:
 
 Claude session filtering:
 - Default behavior excludes automated Claude sessions from `rwd today`.
-- Enable globally with:
+- Task-tool subagent (sidechain) entries are always dropped before counting,
+  so they never inflate the parent session's totals or appear as separate
+  sessions. There is no opt-in to include them.
+- Enable automated-session inclusion globally with:
 ```toml
 [input.claude]
 include_automated = true

--- a/src/parser/claude.rs
+++ b/src/parser/claude.rs
@@ -45,6 +45,10 @@ pub struct UserEntry {
     pub cwd: Option<String>,
     #[serde(default)]
     pub message: Option<serde_json::Value>,
+    /// Marks Task-tool subagent turns. When true, the entry belongs to a
+    /// nested agent invocation rather than the parent interactive session.
+    #[serde(default)]
+    pub is_sidechain: bool,
 }
 
 /// Assistant (AI) response entry.
@@ -60,6 +64,8 @@ pub struct AssistantEntry {
     pub cwd: Option<String>,
     #[serde(default)]
     pub message: Option<AssistantMessage>,
+    #[serde(default)]
+    pub is_sidechain: bool,
 }
 
 /// Detailed structure of an assistant message.
@@ -130,6 +136,8 @@ pub struct ProgressEntry {
     pub entrypoint: Option<String>,
     #[serde(default)]
     pub cwd: Option<String>,
+    #[serde(default)]
+    pub is_sidechain: bool,
 }
 
 /// System entry.
@@ -436,11 +444,34 @@ fn entry_session_id(entry: &LogEntry) -> Option<&str> {
     }
 }
 
+/// Returns true when the entry came from a Task-tool subagent turn.
+///
+/// Sidechain entries share the parent's `session_id` but represent work done
+/// by a nested agent. We exclude them so subagent activity does not double up
+/// the session count or inflate the parent's token totals.
+fn entry_is_sidechain(entry: &LogEntry) -> bool {
+    match entry {
+        LogEntry::User(e) => e.is_sidechain,
+        LogEntry::Assistant(e) => e.is_sidechain,
+        LogEntry::Progress(e) => e.is_sidechain,
+        LogEntry::System(_) | LogEntry::FileHistorySnapshot(_) | LogEntry::Other(_) => false,
+    }
+}
+
 /// Filters automated Claude sessions from entries unless explicitly included.
+///
+/// Subagent (sidechain) entries are always dropped before counting, so a
+/// session that consists entirely of Task-tool turns disappears from the
+/// totals rather than appearing as an extra parent session.
 pub fn filter_automated_sessions(
     entries: Vec<LogEntry>,
     include_automated: bool,
 ) -> SessionFilterResult {
+    let entries: Vec<LogEntry> = entries
+        .into_iter()
+        .filter(|entry| !entry_is_sidechain(entry))
+        .collect();
+
     let automated_session_ids: HashSet<String> = entries
         .iter()
         .filter(|entry| is_automated_entry(entry))
@@ -753,5 +784,60 @@ mod tests {
         assert_eq!(filtered.counts.automated, 2);
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].session_id, "s5");
+    }
+
+    #[test]
+    fn test_filter_automated_sessions_drops_inline_sidechain_entries() {
+        // Parent session with one sidechain (Task subagent) turn mixed in.
+        let entries = vec![
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"parent","timestamp":"2026-03-11T13:00:00Z","uuid":"p1","entrypoint":"cli","isSidechain":false,"message":{"content":"hello"}}"#,
+            )
+            .expect("parent user"),
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"assistant","sessionId":"parent","timestamp":"2026-03-11T13:00:05Z","uuid":"sub-a1","entrypoint":"cli","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"subagent reply"}]}}"#,
+            )
+            .expect("sidechain assistant"),
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"parent","timestamp":"2026-03-11T13:00:10Z","uuid":"p2","entrypoint":"cli","isSidechain":false,"message":{"content":"continue"}}"#,
+            )
+            .expect("parent follow-up"),
+        ];
+
+        let filtered = filter_automated_sessions(entries, false);
+        let summaries = summarize_entries(&filtered.entries);
+
+        assert_eq!(filtered.counts.interactive, 1);
+        assert_eq!(filtered.counts.automated, 0);
+        // Sidechain assistant turn is dropped, so the parent session has 2 user
+        // entries and 0 assistant entries.
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].session_id, "parent");
+        assert_eq!(summaries[0].user_count, 2);
+        assert_eq!(summaries[0].assistant_count, 0);
+    }
+
+    #[test]
+    fn test_filter_automated_sessions_drops_subagent_only_session_from_count() {
+        // A file that contains only sidechain entries (e.g. an `agent-*.jsonl`
+        // file that somehow leaked into the discovery path) should not show up
+        // as a counted session at all.
+        let entries = vec![
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"user","sessionId":"sub-only","timestamp":"2026-03-11T14:00:00Z","uuid":"s1","entrypoint":"cli","isSidechain":true,"message":{"content":"task spec"}}"#,
+            )
+            .expect("sidechain user"),
+            serde_json::from_str::<LogEntry>(
+                r#"{"type":"assistant","sessionId":"sub-only","timestamp":"2026-03-11T14:00:05Z","uuid":"s2","entrypoint":"cli","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"#,
+            )
+            .expect("sidechain assistant"),
+        ];
+
+        let filtered = filter_automated_sessions(entries, false);
+        let summaries = summarize_entries(&filtered.entries);
+
+        assert_eq!(filtered.counts.interactive, 0);
+        assert_eq!(filtered.counts.automated, 0);
+        assert!(summaries.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Claude Code의 Task-tool subagent 호출은 `"isSidechain": true` + 부모 세션의 `session_id`로 JSONL에 인라인 기록됨
- 필터 없이는 부모 세션의 토큰 합계를 부풀리거나, subagent-only 파일이 standalone 세션처럼 카운트되는 문제 발생
- Codex 쪽 subagent 필터링(#139)과 대칭으로 Claude 쪽도 hard-signal(`isSidechain`) 기반으로 무조건 제외

## Behavior
- `UserEntry` / `AssistantEntry` / `ProgressEntry`에 `is_sidechain: bool` 필드 (default `false`, 옛 로그 호환)
- `filter_automated_sessions`가 카운트 전에 sidechain 엔트리를 모두 drop
- subagent-only 세션은 session count에서 사라짐 (interactive/automated 어느 쪽에도 잡히지 않음)
- include 옵션 없음 — Codex 정책과 동일하게 무조건 제외

## Changes
- [src/parser/claude.rs](src/parser/claude.rs): `is_sidechain` 필드, `entry_is_sidechain` helper, 필터 적용 + 2개 unit test
- [README.md](README.md): Claude session filtering 섹션에 sidechain 제외 명시

Fixes #136

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` 224 passed (2 new sidechain tests)