### PR TITLE
chore: bump version to 0.13.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,7 +1562,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rwd"
-version = "0.13.16"
+version = "0.13.17"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rwd"
-version = "0.13.16"
+version = "0.13.17"
 edition = "2024"
 description = "CLI tool that analyzes AI coding session logs and extracts daily development insights"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.13.16 to 0.13.17